### PR TITLE
Clean up the examples

### DIFF
--- a/examples/array/example_array_at_if.hpp
+++ b/examples/array/example_array_at_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_AT_IF_HPP
-#define EXAMPLE_ARRAY_AT_IF_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -52,5 +49,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/array/example_array_back.hpp
+++ b/examples/array/example_array_back.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_BACK_HPP
-#define EXAMPLE_ARRAY_BACK_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -51,5 +48,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/array/example_array_back_if.hpp
+++ b/examples/array/example_array_back_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_BACK_IF_HPP
-#define EXAMPLE_ARRAY_BACK_IF_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -52,5 +49,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/array/example_array_begin.hpp
+++ b/examples/array/example_array_begin.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_BEGIN_HPP
-#define EXAMPLE_ARRAY_BEGIN_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -52,5 +49,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/array/example_array_data.hpp
+++ b/examples/array/example_array_data.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_DATA_HPP
-#define EXAMPLE_ARRAY_DATA_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -51,5 +48,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/array/example_array_empty.hpp
+++ b/examples/array/example_array_empty.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_EMPTY_HPP
-#define EXAMPLE_ARRAY_EMPTY_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -51,5 +48,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/array/example_array_end.hpp
+++ b/examples/array/example_array_end.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_END_HPP
-#define EXAMPLE_ARRAY_END_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -52,5 +49,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/array/example_array_equals.hpp
+++ b/examples/array/example_array_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_EQUALS_HPP
-#define EXAMPLE_ARRAY_EQUALS_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -57,5 +54,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/array/example_array_front.hpp
+++ b/examples/array/example_array_front.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_FRONT_HPP
-#define EXAMPLE_ARRAY_FRONT_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -51,5 +48,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/array/example_array_front_if.hpp
+++ b/examples/array/example_array_front_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_FRONT_IF_HPP
-#define EXAMPLE_ARRAY_FRONT_IF_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -52,5 +49,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/array/example_array_iter.hpp
+++ b/examples/array/example_array_iter.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_ITER_HPP
-#define EXAMPLE_ARRAY_ITER_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -55,5 +52,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/array/example_array_max_size.hpp
+++ b/examples/array/example_array_max_size.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_MAX_SIZE_HPP
-#define EXAMPLE_ARRAY_MAX_SIZE_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -48,5 +45,3 @@ namespace bsl
         bsl::print() << "max size: " << arr.max_size() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/array/example_array_not_equals.hpp
+++ b/examples/array/example_array_not_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_NOT_EQUALS_HPP
-#define EXAMPLE_ARRAY_NOT_EQUALS_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -57,5 +54,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/array/example_array_rbegin.hpp
+++ b/examples/array/example_array_rbegin.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_RBEGIN_HPP
-#define EXAMPLE_ARRAY_RBEGIN_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -52,5 +49,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/array/example_array_rend.hpp
+++ b/examples/array/example_array_rend.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_REND_HPP
-#define EXAMPLE_ARRAY_REND_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -52,5 +49,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/array/example_array_riter.hpp
+++ b/examples/array/example_array_riter.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_RITER_HPP
-#define EXAMPLE_ARRAY_RITER_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -55,5 +52,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/array/example_array_size.hpp
+++ b/examples/array/example_array_size.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_SIZE_HPP
-#define EXAMPLE_ARRAY_SIZE_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -48,5 +45,3 @@ namespace bsl
         bsl::print() << "size: " << arr.size() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/array/example_array_size_bytes.hpp
+++ b/examples/array/example_array_size_bytes.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_SIZE_BYTES_HPP
-#define EXAMPLE_ARRAY_SIZE_BYTES_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -48,5 +45,3 @@ namespace bsl
         bsl::print() << "size in bytes: " << arr.size_bytes() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/basic_errc_type/example_basic_errc_type_constructor_t.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_constructor_t.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_CONSTRUCTOR_T_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_CONSTRUCTOR_T_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_errc_type/example_basic_errc_type_equals.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_EQUALS_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_EQUALS_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -47,5 +44,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_errc_type/example_basic_errc_type_failure.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_failure.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_FAILURE_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_FAILURE_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_errc_type/example_basic_errc_type_get.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_get.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_GET_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_GET_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_errc_type/example_basic_errc_type_is_checked.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_is_checked.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_IS_CHECKED_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_IS_CHECKED_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_errc_type/example_basic_errc_type_is_unchecked.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_is_unchecked.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_IS_UNCHECKED_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_IS_UNCHECKED_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_errc_type/example_basic_errc_type_message.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_message.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_MESSAGE_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_MESSAGE_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << errc_success.message() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/basic_errc_type/example_basic_errc_type_not_equals.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_not_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_NOT_EQUALS_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_NOT_EQUALS_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -47,5 +44,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_errc_type/example_basic_errc_type_success.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_success.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_SUCCESS_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_SUCCESS_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_at_if.hpp
+++ b/examples/basic_string_view/example_basic_string_view_at_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_AT_IF_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_AT_IF_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_back_if.hpp
+++ b/examples/basic_string_view/example_basic_string_view_back_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_BACK_IF_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_BACK_IF_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_begin.hpp
+++ b/examples/basic_string_view/example_basic_string_view_begin.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_BEGIN_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_BEGIN_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -44,5 +41,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_compare.hpp
+++ b/examples/basic_string_view/example_basic_string_view_compare.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_COMPARE_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_COMPARE_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_data.hpp
+++ b/examples/basic_string_view/example_basic_string_view_data.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_DATA_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_DATA_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_default_constructor.hpp
+++ b/examples/basic_string_view/example_basic_string_view_default_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_DEFAULT_CONSTRUCTOR_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_DEFAULT_CONSTRUCTOR_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_empty.hpp
+++ b/examples/basic_string_view/example_basic_string_view_empty.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_EMPTY_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_EMPTY_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_end.hpp
+++ b/examples/basic_string_view/example_basic_string_view_end.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_END_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_END_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -44,5 +41,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_ends_with.hpp
+++ b/examples/basic_string_view/example_basic_string_view_ends_with.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_ENDS_WITH_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_ENDS_WITH_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_equals.hpp
+++ b/examples/basic_string_view/example_basic_string_view_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_EQUALS_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_EQUALS_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_front_if.hpp
+++ b/examples/basic_string_view/example_basic_string_view_front_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_FRONT_IF_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_FRONT_IF_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_iter.hpp
+++ b/examples/basic_string_view/example_basic_string_view_iter.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_ITER_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_ITER_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -46,5 +43,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_length.hpp
+++ b/examples/basic_string_view/example_basic_string_view_length.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_LENGTH_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_LENGTH_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_max_size.hpp
+++ b/examples/basic_string_view/example_basic_string_view_max_size.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_MAX_SIZE_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_MAX_SIZE_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -40,5 +37,3 @@ namespace bsl
         bsl::print() << "max size: " << str.max_size() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_not_equals.hpp
+++ b/examples/basic_string_view/example_basic_string_view_not_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_NOT_EQUALS_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_NOT_EQUALS_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_rbegin.hpp
+++ b/examples/basic_string_view/example_basic_string_view_rbegin.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_RBEGIN_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_RBEGIN_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -44,5 +41,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_remove_prefix.hpp
+++ b/examples/basic_string_view/example_basic_string_view_remove_prefix.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_REMOVE_PREFIX_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_REMOVE_PREFIX_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_remove_suffix.hpp
+++ b/examples/basic_string_view/example_basic_string_view_remove_suffix.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_REMOVE_SUFFIX_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_REMOVE_SUFFIX_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_rend.hpp
+++ b/examples/basic_string_view/example_basic_string_view_rend.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_REND_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_REND_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -44,5 +41,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_riter.hpp
+++ b/examples/basic_string_view/example_basic_string_view_riter.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_RITER_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_RITER_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -46,5 +43,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_s_assignment.hpp
+++ b/examples/basic_string_view/example_basic_string_view_s_assignment.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_S_ASSIGNMENT_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_S_ASSIGNMENT_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_s_constructor.hpp
+++ b/examples/basic_string_view/example_basic_string_view_s_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_S_CONSTRUCTOR_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_S_CONSTRUCTOR_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_size.hpp
+++ b/examples/basic_string_view/example_basic_string_view_size.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_SIZE_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_SIZE_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -40,5 +37,3 @@ namespace bsl
         bsl::print() << "size: " << str.size() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_size_bytes.hpp
+++ b/examples/basic_string_view/example_basic_string_view_size_bytes.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_SIZE_BYTES_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_SIZE_BYTES_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -40,5 +37,3 @@ namespace bsl
         bsl::print() << "size in bytes: " << str.size_bytes() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_starts_with.hpp
+++ b/examples/basic_string_view/example_basic_string_view_starts_with.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_STARTS_WITH_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_STARTS_WITH_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/basic_string_view/example_basic_string_view_substr.hpp
+++ b/examples/basic_string_view/example_basic_string_view_substr.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_SUBSTR_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_SUBSTR_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_and.hpp
+++ b/examples/byte/example_byte_and.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_AND_HPP
-#define EXAMPLE_BYTE_AND_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -48,5 +45,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_and_assign.hpp
+++ b/examples/byte/example_byte_and_assign.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_AND_ASSIGN_HPP
-#define EXAMPLE_BYTE_AND_ASSIGN_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -49,5 +46,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_by_value_constructor.hpp
+++ b/examples/byte/example_byte_by_value_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_BY_VALUE_CONSTRUCTOR_HPP
-#define EXAMPLE_BYTE_BY_VALUE_CONSTRUCTOR_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_complement.hpp
+++ b/examples/byte/example_byte_complement.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_COMPLEMENT_HPP
-#define EXAMPLE_BYTE_COMPLEMENT_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_default_constructor.hpp
+++ b/examples/byte/example_byte_default_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_DEFAULT_CONSTRUCTOR_HPP
-#define EXAMPLE_BYTE_DEFAULT_CONSTRUCTOR_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -46,5 +43,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_equal.hpp
+++ b/examples/byte/example_byte_equal.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_EQUAL_HPP
-#define EXAMPLE_BYTE_EQUAL_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -47,5 +44,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_lshift.hpp
+++ b/examples/byte/example_byte_lshift.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_LSHIFT_HPP
-#define EXAMPLE_BYTE_LSHIFT_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -46,5 +43,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_lshift_assign.hpp
+++ b/examples/byte/example_byte_lshift_assign.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_LSHIFT_ASSIGN_HPP
-#define EXAMPLE_BYTE_LSHIFT_ASSIGN_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -47,5 +44,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_not_equal.hpp
+++ b/examples/byte/example_byte_not_equal.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_NOT_EQUAL_HPP
-#define EXAMPLE_BYTE_NOT_EQUAL_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -47,5 +44,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_or.hpp
+++ b/examples/byte/example_byte_or.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_OR_HPP
-#define EXAMPLE_BYTE_OR_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -48,5 +45,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_or_assign.hpp
+++ b/examples/byte/example_byte_or_assign.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_OR_ASSIGN_HPP
-#define EXAMPLE_BYTE_OR_ASSIGN_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -49,5 +46,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_rshift.hpp
+++ b/examples/byte/example_byte_rshift.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_RSHIFT_HPP
-#define EXAMPLE_BYTE_RSHIFT_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -46,5 +43,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_rshift_assign.hpp
+++ b/examples/byte/example_byte_rshift_assign.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_RSHIFT_ASSIGN_HPP
-#define EXAMPLE_BYTE_RSHIFT_ASSIGN_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -47,5 +44,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_to_integer.hpp
+++ b/examples/byte/example_byte_to_integer.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_TO_INTEGER_HPP
-#define EXAMPLE_BYTE_TO_INTEGER_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_xor.hpp
+++ b/examples/byte/example_byte_xor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_XOR_HPP
-#define EXAMPLE_BYTE_XOR_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -48,5 +45,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/byte/example_byte_xor_assign.hpp
+++ b/examples/byte/example_byte_xor_assign.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_XOR_ASSIGN_HPP
-#define EXAMPLE_BYTE_XOR_ASSIGN_HPP
-
 #include <bsl/debug.hpp>
 #include <bsl/byte.hpp>
 
@@ -49,5 +46,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_compare.hpp
+++ b/examples/char_traits/example_char_traits_compare.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_COMPARE_HPP
-#define EXAMPLE_CHAR_TRAITS_COMPARE_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_eof.hpp
+++ b/examples/char_traits/example_char_traits_eof.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_EOF_HPP
-#define EXAMPLE_CHAR_TRAITS_EOF_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -48,5 +45,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_eq.hpp
+++ b/examples/char_traits/example_char_traits_eq.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_EQ_HPP
-#define EXAMPLE_CHAR_TRAITS_EQ_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_eq_int_type.hpp
+++ b/examples/char_traits/example_char_traits_eq_int_type.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_EQ_INT_TYPE_HPP
-#define EXAMPLE_CHAR_TRAITS_EQ_INT_TYPE_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_find.hpp
+++ b/examples/char_traits/example_char_traits_find.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_FIND_HPP
-#define EXAMPLE_CHAR_TRAITS_FIND_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_length.hpp
+++ b/examples/char_traits/example_char_traits_length.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_LENGTH_HPP
-#define EXAMPLE_CHAR_TRAITS_LENGTH_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_lt.hpp
+++ b/examples/char_traits/example_char_traits_lt.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_LT_HPP
-#define EXAMPLE_CHAR_TRAITS_LT_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_not_eof.hpp
+++ b/examples/char_traits/example_char_traits_not_eof.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_NOT_EOF_HPP
-#define EXAMPLE_CHAR_TRAITS_NOT_EOF_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -48,5 +45,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_to_char_type.hpp
+++ b/examples/char_traits/example_char_traits_to_char_type.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_TO_CHAR_TYPE_HPP
-#define EXAMPLE_CHAR_TRAITS_TO_CHAR_TYPE_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/char_traits/example_char_traits_to_int_type.hpp
+++ b/examples/char_traits/example_char_traits_to_int_type.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_TO_INT_TYPE_HPP
-#define EXAMPLE_CHAR_TRAITS_TO_INT_TYPE_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_data.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_data.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_DATA_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_DATA_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_decrement.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_decrement.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_DECREMENT_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_DECREMENT_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_empty.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_empty.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_EMPTY_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_EMPTY_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_equals.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_EQUALS_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_EQUALS_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_get_if.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_get_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_GET_IF_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_GET_IF_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_gt.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_gt.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_GT_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_GT_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_gt_equals.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_gt_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_GT_EQUALS_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_GT_EQUALS_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_increment.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_increment.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_INCREMENT_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_INCREMENT_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_index.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_index.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_INDEX_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_INDEX_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_is_end.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_is_end.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_IS_END_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_IS_END_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_lt.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_lt.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_LT_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_LT_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_lt_equals.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_lt_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_LT_EQUALS_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_LT_EQUALS_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_not_equals.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_not_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_NOT_EQUALS_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_NOT_EQUALS_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/contiguous_iterator/example_contiguous_iterator_size.hpp
+++ b/examples/contiguous_iterator/example_contiguous_iterator_size.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_SIZE_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_SIZE_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/debug/example_debug_alert.hpp
+++ b/examples/debug/example_debug_alert.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DEBUG_ALERT_HPP
-#define EXAMPLE_DEBUG_ALERT_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -39,5 +36,3 @@ namespace bsl
         bsl::alert() << "example message: " << val << bsl::endl;
     }
 }
-
-#endif

--- a/examples/debug/example_debug_debug.hpp
+++ b/examples/debug/example_debug_debug.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DEBUG_DEBUG_HPP
-#define EXAMPLE_DEBUG_DEBUG_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -39,5 +36,3 @@ namespace bsl
         bsl::debug() << "example message: " << val << bsl::endl;
     }
 }
-
-#endif

--- a/examples/debug/example_debug_error.hpp
+++ b/examples/debug/example_debug_error.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DEBUG_ERROR_HPP
-#define EXAMPLE_DEBUG_ERROR_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -39,5 +36,3 @@ namespace bsl
         bsl::error() << "example message: " << val << bsl::endl;
     }
 }
-
-#endif

--- a/examples/debug/example_debug_print.hpp
+++ b/examples/debug/example_debug_print.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DEBUG_PRINT_HPP
-#define EXAMPLE_DEBUG_PRINT_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << "example message: " << val << bsl::endl;
     }
 }
-
-#endif

--- a/examples/example_add_const_overview.hpp
+++ b/examples/example_add_const_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ADD_CONST_OVERVIEW_HPP
-#define EXAMPLE_ADD_CONST_OVERVIEW_HPP
-
 #include <bsl/add_const.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_add_lvalue_reference_overview.hpp
+++ b/examples/example_add_lvalue_reference_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ADD_LVALUE_REFERENCE_OVERVIEW_HPP
-#define EXAMPLE_ADD_LVALUE_REFERENCE_OVERVIEW_HPP
-
 #include <bsl/add_lvalue_reference.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_add_pointer_overview.hpp
+++ b/examples/example_add_pointer_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ADD_POINTER_OVERVIEW_HPP
-#define EXAMPLE_ADD_POINTER_OVERVIEW_HPP
-
 #include <bsl/add_pointer.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_add_rvalue_reference_overview.hpp
+++ b/examples/example_add_rvalue_reference_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ADD_RVALUE_REFERENCE_OVERVIEW_HPP
-#define EXAMPLE_ADD_RVALUE_REFERENCE_OVERVIEW_HPP
-
 #include <bsl/add_rvalue_reference.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_addressof_overview.hpp
+++ b/examples/example_addressof_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ADDRESSOF_OVERVIEW_HPP
-#define EXAMPLE_ADDRESSOF_OVERVIEW_HPP
-
 #include <bsl/addressof.hpp>
 #include <bsl/debug.hpp>
 
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_aligned_storage_overview.hpp
+++ b/examples/example_aligned_storage_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ALIGNED_STORAGE_OVERVIEW_HPP
-#define EXAMPLE_ALIGNED_STORAGE_OVERVIEW_HPP
-
 #include <bsl/aligned_storage.hpp>
 #include <bsl/alignment_of.hpp>
 #include <bsl/debug.hpp>
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_aligned_union_overview.hpp
+++ b/examples/example_aligned_union_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ALIGNED_UNION_OVERVIEW_HPP
-#define EXAMPLE_ALIGNED_UNION_OVERVIEW_HPP
-
 #include <bsl/aligned_union.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_alignment_of_overview.hpp
+++ b/examples/example_alignment_of_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ALIGNMENT_OF_OVERVIEW_HPP
-#define EXAMPLE_ALIGNMENT_OF_OVERVIEW_HPP
-
 #include <bsl/aligned_storage.hpp>
 #include <bsl/alignment_of.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_array_overview.hpp
+++ b/examples/example_array_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ARRAY_OVERVIEW_HPP
-#define EXAMPLE_ARRAY_OVERVIEW_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -52,5 +49,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/example_as_const_overview.hpp
+++ b/examples/example_as_const_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_AS_CONST_OVERVIEW_HPP
-#define EXAMPLE_AS_CONST_OVERVIEW_HPP
-
 #include <bsl/as_const.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_basic_errc_type_overview.hpp
+++ b/examples/example_basic_errc_type_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_ERRC_TYPE_OVERVIEW_HPP
-#define EXAMPLE_BASIC_ERRC_TYPE_OVERVIEW_HPP
-
 #include <bsl/errc_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -55,5 +52,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_basic_string_view_overview.hpp
+++ b/examples/example_basic_string_view_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BASIC_STRING_VIEW_OVERVIEW_HPP
-#define EXAMPLE_BASIC_STRING_VIEW_OVERVIEW_HPP
-
 #include <bsl/basic_string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_bool_constant_overview.hpp
+++ b/examples/example_bool_constant_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BOOL_CONSTANT_OVERVIEW_HPP
-#define EXAMPLE_BOOL_CONSTANT_OVERVIEW_HPP
-
 #include <bsl/bool_constant.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_byte_overview.hpp
+++ b/examples/example_byte_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_BYTE_OVERVIEW_HPP
-#define EXAMPLE_BYTE_OVERVIEW_HPP
-
 #include <bsl/byte.hpp>
 #include <bsl/debug.hpp>
 
@@ -40,5 +37,3 @@ namespace bsl
         bsl::print() << "success: " << mybyte.to_integer();
     }
 }
-
-#endif

--- a/examples/example_char_traits_overview.hpp
+++ b/examples/example_char_traits_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CHAR_TRAITS_OVERVIEW_HPP
-#define EXAMPLE_CHAR_TRAITS_OVERVIEW_HPP
-
 #include <bsl/char_traits.hpp>
 #include <bsl/debug.hpp>
 
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_color_overview.hpp
+++ b/examples/example_color_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_COLOR_OVERVIEW_HPP
-#define EXAMPLE_COLOR_OVERVIEW_HPP
-
 #include <bsl/color.hpp>
 #include <bsl/debug.hpp>
 
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << bsl::green << "success" << bsl::reset_color << bsl::endl;
     }
 }
-
-#endif

--- a/examples/example_common_type_overview.hpp
+++ b/examples/example_common_type_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_COMMON_TYPE_OVERVIEW_HPP
-#define EXAMPLE_COMMON_TYPE_OVERVIEW_HPP
-
 #include <bsl/common_type.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -48,5 +45,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_conditional_overview.hpp
+++ b/examples/example_conditional_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONDITIONAL_OVERVIEW_HPP
-#define EXAMPLE_CONDITIONAL_OVERVIEW_HPP
-
 #include <bsl/conditional.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -46,5 +43,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_conjunction_overview.hpp
+++ b/examples/example_conjunction_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONJUNCTION_OVERVIEW_HPP
-#define EXAMPLE_CONJUNCTION_OVERVIEW_HPP
-
 #include <bsl/conjunction.hpp>
 #include <bsl/is_bool.hpp>
 #include <bsl/is_void.hpp>
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_contiguous_iterator_overview.hpp
+++ b/examples/example_contiguous_iterator_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_CONTIGUOUS_ITERATOR_OVERVIEW_HPP
-#define EXAMPLE_CONTIGUOUS_ITERATOR_OVERVIEW_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -45,5 +42,3 @@ namespace bsl
         bsl::print() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/example_decay_overview.hpp
+++ b/examples/example_decay_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DECAY_OVERVIEW_HPP
-#define EXAMPLE_DECAY_OVERVIEW_HPP
-
 #include <bsl/decay.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_declval_overview.hpp
+++ b/examples/example_declval_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DECLVAL_OVERVIEW_HPP
-#define EXAMPLE_DECLVAL_OVERVIEW_HPP
-
 #include <bsl/declval.hpp>
 #include <bsl/is_same.hpp>
 #include "example_class_nodefault.hpp"
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_destroy_at_overview.hpp
+++ b/examples/example_destroy_at_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DESTROY_AT_OVERVIEW_HPP
-#define EXAMPLE_DESTROY_AT_OVERVIEW_HPP
-
 #include <bsl/destroy_at.hpp>
 #include <bsl/debug.hpp>
 
@@ -49,5 +46,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_detected_or_overview.hpp
+++ b/examples/example_detected_or_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DETECTED_OR_OVERVIEW_HPP
-#define EXAMPLE_DETECTED_OR_OVERVIEW_HPP
-
 #include <bsl/detected_or.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -50,5 +47,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_detected_overview.hpp
+++ b/examples/example_detected_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DETECTED_OVERVIEW_HPP
-#define EXAMPLE_DETECTED_OVERVIEW_HPP
-
 #include <bsl/detected.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -49,5 +46,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_discard_overview.hpp
+++ b/examples/example_discard_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DISCARD_OVERVIEW_HPP
-#define EXAMPLE_DISCARD_OVERVIEW_HPP
-
 #include <bsl/discard.hpp>
 #include <bsl/debug.hpp>
 
@@ -42,5 +39,3 @@ namespace bsl
         bsl::print() << "success\n";
     }
 }
-
-#endif

--- a/examples/example_disjunction_overview.hpp
+++ b/examples/example_disjunction_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_DISJUNCTION_OVERVIEW_HPP
-#define EXAMPLE_DISJUNCTION_OVERVIEW_HPP
-
 #include <bsl/disjunction.hpp>
 #include <bsl/is_bool.hpp>
 #include <bsl/is_void.hpp>
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_enable_if_overview.hpp
+++ b/examples/example_enable_if_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_ENABLE_IF_OVERVIEW_HPP
-#define EXAMPLE_ENABLE_IF_OVERVIEW_HPP
-
 #include <bsl/enable_if.hpp>
 #include <bsl/debug.hpp>
 
@@ -77,5 +74,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_exchange_overview.hpp
+++ b/examples/example_exchange_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_EXCHANGE_OVERVIEW_HPP
-#define EXAMPLE_EXCHANGE_OVERVIEW_HPP
-
 #include <bsl/exchange.hpp>
 #include <bsl/debug.hpp>
 
@@ -52,5 +49,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_extent_overview.hpp
+++ b/examples/example_extent_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_EXTENT_OVERVIEW_HPP
-#define EXAMPLE_EXTENT_OVERVIEW_HPP
-
 #include <bsl/extent.hpp>
 #include <bsl/debug.hpp>
 
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_false_type_overview.hpp
+++ b/examples/example_false_type_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FALSE_TYPE_OVERVIEW_HPP
-#define EXAMPLE_FALSE_TYPE_OVERVIEW_HPP
-
 #include <bsl/false_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_fill_overview.hpp
+++ b/examples/example_fill_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FILL_OVERVIEW_HPP
-#define EXAMPLE_FILL_OVERVIEW_HPP
-
 #include <bsl/fill.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -54,5 +51,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_for_each_overview.hpp
+++ b/examples/example_for_each_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FOREACH_OVERVIEW_HPP
-#define EXAMPLE_FOREACH_OVERVIEW_HPP
-
 #include <bsl/for_each.hpp>
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
@@ -96,5 +93,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/example_forward_overview.hpp
+++ b/examples/example_forward_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FORWARD_OVERVIEW_HPP
-#define EXAMPLE_FORWARD_OVERVIEW_HPP
-
 #include <bsl/forward.hpp>
 #include <bsl/discard.hpp>
 #include <bsl/is_lvalue_reference.hpp>
@@ -87,5 +84,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_has_unique_object_representations_overview.hpp
+++ b/examples/example_has_unique_object_representations_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_HAS_UNIQUE_OBJECT_REPRESENTATIONS_OVERVIEW_HPP
-#define EXAMPLE_HAS_UNIQUE_OBJECT_REPRESENTATIONS_OVERVIEW_HPP
-
 #include <bsl/has_unique_object_representations.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_has_virtual_destructor_overview.hpp
+++ b/examples/example_has_virtual_destructor_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_HAS_VIRTUAL_DESTRUCTOR_OVERVIEW_HPP
-#define EXAMPLE_HAS_VIRTUAL_DESTRUCTOR_OVERVIEW_HPP
-
 #include <bsl/has_virtual_destructor.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_in_place_overview.hpp
+++ b/examples/example_in_place_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IN_PLACE_OVERVIEW_HPP
-#define EXAMPLE_IN_PLACE_OVERVIEW_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_integer_sequence_overview.hpp
+++ b/examples/example_integer_sequence_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_INTEGER_SEQUENCE_OVERVIEW_HPP
-#define EXAMPLE_INTEGER_SEQUENCE_OVERVIEW_HPP
-
 #include <bsl/integer_sequence.hpp>
 #include <bsl/debug.hpp>
 
@@ -53,5 +50,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_integral_constant_overview.hpp
+++ b/examples/example_integral_constant_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_INTEGRAL_CONSTANT_OVERVIEW_HPP
-#define EXAMPLE_INTEGRAL_CONSTANT_OVERVIEW_HPP
-
 #include <bsl/integral_constant.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_invoke_overview.hpp
+++ b/examples/example_invoke_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_INVOKE_OVERVIEW_HPP
-#define EXAMPLE_INVOKE_OVERVIEW_HPP
-
 #include <bsl/invoke.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_invoke_result_overview.hpp
+++ b/examples/example_invoke_result_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_INVOKE_RESULT_OVERVIEW_HPP
-#define EXAMPLE_INVOKE_RESULT_OVERVIEW_HPP
-
 #include <bsl/invoke_result.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_abstract_overview.hpp
+++ b/examples/example_is_abstract_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_ABSTRACT_OVERVIEW_HPP
-#define EXAMPLE_IS_ABSTRACT_OVERVIEW_HPP
-
 #include <bsl/is_abstract.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_aggregate_overview.hpp
+++ b/examples/example_is_aggregate_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_AGGREGATE_OVERVIEW_HPP
-#define EXAMPLE_IS_AGGREGATE_OVERVIEW_HPP
-
 #include <bsl/is_aggregate.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_arithmetic_overview.hpp
+++ b/examples/example_is_arithmetic_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_ARITHMETIC_OVERVIEW_HPP
-#define EXAMPLE_IS_ARITHMETIC_OVERVIEW_HPP
-
 #include <bsl/is_arithmetic.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_array_overview.hpp
+++ b/examples/example_is_array_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_ARRAY_OVERVIEW_HPP
-#define EXAMPLE_IS_ARRAY_OVERVIEW_HPP
-
 #include <bsl/is_array.hpp>
 #include <bsl/debug.hpp>
 
@@ -46,5 +43,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_assignable_overview.hpp
+++ b/examples/example_is_assignable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_ASSIGNABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_ASSIGNABLE_OVERVIEW_HPP
-
 #include <bsl/is_assignable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_base_of_overview.hpp
+++ b/examples/example_is_base_of_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_BASE_OF_OVERVIEW_HPP
-#define EXAMPLE_IS_BASE_OF_OVERVIEW_HPP
-
 #include <bsl/is_base_of.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_bool_overview.hpp
+++ b/examples/example_is_bool_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_BOOL_OVERVIEW_HPP
-#define EXAMPLE_IS_BOOL_OVERVIEW_HPP
-
 #include <bsl/is_bool.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_bounded_array_overview.hpp
+++ b/examples/example_is_bounded_array_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_BOUNDED_ARRAY_OVERVIEW_HPP
-#define EXAMPLE_IS_BOUNDED_ARRAY_OVERVIEW_HPP
-
 #include <bsl/is_bounded_array.hpp>
 
 namespace bsl
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_class_overview.hpp
+++ b/examples/example_is_class_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_CLASS_OVERVIEW_HPP
-#define EXAMPLE_IS_CLASS_OVERVIEW_HPP
-
 #include <bsl/is_class.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_compound_overview.hpp
+++ b/examples/example_is_compound_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_COMPOUND_OVERVIEW_HPP
-#define EXAMPLE_IS_COMPOUND_OVERVIEW_HPP
-
 #include <bsl/is_compound.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_const_overview.hpp
+++ b/examples/example_is_const_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_CONST_OVERVIEW_HPP
-#define EXAMPLE_IS_CONST_OVERVIEW_HPP
-
 #include <bsl/is_const.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_constant_evaluated_overview.hpp
+++ b/examples/example_is_constant_evaluated_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_CONSTANT_EVALUATED_OVERVIEW_HPP
-#define EXAMPLE_IS_CONSTANT_EVALUATED_OVERVIEW_HPP
-
 #include <bsl/is_constant_evaluated.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_constructible_overview.hpp
+++ b/examples/example_is_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_convertible_overview.hpp
+++ b/examples/example_is_convertible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_CONVERTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_CONVERTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_convertible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_copy_assignable_overview.hpp
+++ b/examples/example_is_copy_assignable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_COPY_ASSIGNABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_COPY_ASSIGNABLE_OVERVIEW_HPP
-
 #include <bsl/is_copy_assignable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_copy_constructible_overview.hpp
+++ b/examples/example_is_copy_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_COPY_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_COPY_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_copy_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_copyable_overview.hpp
+++ b/examples/example_is_copyable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_COPYABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_COPYABLE_OVERVIEW_HPP
-
 #include <bsl/is_copyable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_default_constructible_overview.hpp
+++ b/examples/example_is_default_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_DEFAULT_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_DEFAULT_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_default_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_destructible_overview.hpp
+++ b/examples/example_is_destructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_DESTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_DESTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_destructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_detected_overview.hpp
+++ b/examples/example_is_detected_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_DETECTED_OVERVIEW_HPP
-#define EXAMPLE_IS_DETECTED_OVERVIEW_HPP
-
 #include <bsl/is_detected.hpp>
 #include <bsl/debug.hpp>
 
@@ -46,5 +43,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_empty_overview.hpp
+++ b/examples/example_is_empty_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_EMPTY_OVERVIEW_HPP
-#define EXAMPLE_IS_EMPTY_OVERVIEW_HPP
-
 #include <bsl/is_empty.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_enum_overview.hpp
+++ b/examples/example_is_enum_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_ENUM_OVERVIEW_HPP
-#define EXAMPLE_IS_ENUM_OVERVIEW_HPP
-
 #include <bsl/is_enum.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_final_overview.hpp
+++ b/examples/example_is_final_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_FINAL_OVERVIEW_HPP
-#define EXAMPLE_IS_FINAL_OVERVIEW_HPP
-
 #include <bsl/is_final.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_function_overview.hpp
+++ b/examples/example_is_function_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_FUNCTION_OVERVIEW_HPP
-#define EXAMPLE_IS_FUNCTION_OVERVIEW_HPP
-
 #include <bsl/is_function.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_fundamental_overview.hpp
+++ b/examples/example_is_fundamental_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_FUNDAMENTAL_OVERVIEW_HPP
-#define EXAMPLE_IS_FUNDAMENTAL_OVERVIEW_HPP
-
 #include <bsl/is_fundamental.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_integral_overview.hpp
+++ b/examples/example_is_integral_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_INTEGEAL_OVERVIEW_HPP
-#define EXAMPLE_IS_INTEGEAL_OVERVIEW_HPP
-
 #include <bsl/is_integral.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_invocable_overview.hpp
+++ b/examples/example_is_invocable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_INVOCABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_INVOCABLE_OVERVIEW_HPP
-
 #include <bsl/is_invocable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_invocable_r_overview.hpp
+++ b/examples/example_is_invocable_r_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_INVOCABLE_R_OVERVIEW_HPP
-#define EXAMPLE_IS_INVOCABLE_R_OVERVIEW_HPP
-
 #include <bsl/is_invocable_r.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_lvalue_reference_overview.hpp
+++ b/examples/example_is_lvalue_reference_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_LVALUE_REFERENCE_OVERVIEW_HPP
-#define EXAMPLE_IS_LVALUE_REFERENCE_OVERVIEW_HPP
-
 #include <bsl/is_lvalue_reference.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_member_function_pointer_overview.hpp
+++ b/examples/example_is_member_function_pointer_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_MEMBER_FUNCTION_POINTER_OVERVIEW_HPP
-#define EXAMPLE_IS_MEMBER_FUNCTION_POINTER_OVERVIEW_HPP
-
 #include <bsl/is_member_function_pointer.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_member_object_pointer_overview.hpp
+++ b/examples/example_is_member_object_pointer_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_MEMBER_OBJECT_POINTER_OVERVIEW_HPP
-#define EXAMPLE_IS_MEMBER_OBJECT_POINTER_OVERVIEW_HPP
-
 #include <bsl/is_member_object_pointer.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_member_pointer_overview.hpp
+++ b/examples/example_is_member_pointer_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_MEMBER_POINTER_OVERVIEW_HPP
-#define EXAMPLE_IS_MEMBER_POINTER_OVERVIEW_HPP
-
 #include <bsl/is_member_pointer.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_movable_overview.hpp
+++ b/examples/example_is_movable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_MOVABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_MOVABLE_OVERVIEW_HPP
-
 #include <bsl/is_movable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_move_assignable_overview.hpp
+++ b/examples/example_is_move_assignable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_MOVE_ASSIGNABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_MOVE_ASSIGNABLE_OVERVIEW_HPP
-
 #include <bsl/is_move_assignable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_move_constructible_overview.hpp
+++ b/examples/example_is_move_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_MOVE_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_MOVE_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_move_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_assignable_overview.hpp
+++ b/examples/example_is_nothrow_assignable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_ASSIGNABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_ASSIGNABLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_assignable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_constructible_overview.hpp
+++ b/examples/example_is_nothrow_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_convertible_overview.hpp
+++ b/examples/example_is_nothrow_convertible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_CONVERTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_CONVERTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_convertible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_copy_assignable_overview.hpp
+++ b/examples/example_is_nothrow_copy_assignable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_COPY_ASSIGNABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_COPY_ASSIGNABLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_copy_assignable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_copy_constructible_overview.hpp
+++ b/examples/example_is_nothrow_copy_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_COPY_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_COPY_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_copy_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_copyable_overview.hpp
+++ b/examples/example_is_nothrow_copyable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_COPYABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_COPYABLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_copyable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_default_constructible_overview.hpp
+++ b/examples/example_is_nothrow_default_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_DEFAULT_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_DEFAULT_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_default_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_destructible_overview.hpp
+++ b/examples/example_is_nothrow_destructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_DESTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_DESTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_destructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_invocable_overview.hpp
+++ b/examples/example_is_nothrow_invocable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_INVOCABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_INVOCABLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_invocable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_invocable_r_overview.hpp
+++ b/examples/example_is_nothrow_invocable_r_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_INVOCABLE_R_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_INVOCABLE_R_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_invocable_r.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_movable_overview.hpp
+++ b/examples/example_is_nothrow_movable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_MOVABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_MOVABLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_movable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_move_assignable_overview.hpp
+++ b/examples/example_is_nothrow_move_assignable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_MOVE_ASSIGNABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_MOVE_ASSIGNABLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_move_assignable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_move_constructible_overview.hpp
+++ b/examples/example_is_nothrow_move_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_MOVE_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_NOTHROW_MOVE_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_nothrow_move_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_swappable_overview.hpp
+++ b/examples/example_is_nothrow_swappable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_SWAPPABLE_HPP
-#define EXAMPLE_IS_NOTHROW_SWAPPABLE_HPP
-
 #include <bsl/is_nothrow_swappable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_nothrow_swappable_with_overview.hpp
+++ b/examples/example_is_nothrow_swappable_with_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NOTHROW_SWAPPABLE_WITH_HPP
-#define EXAMPLE_IS_NOTHROW_SWAPPABLE_WITH_HPP
-
 #include <bsl/is_nothrow_swappable_with.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_null_pointer_overview.hpp
+++ b/examples/example_is_null_pointer_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_NULL_POINTER_OVERVIEW_HPP
-#define EXAMPLE_IS_NULL_POINTER_OVERVIEW_HPP
-
 #include <bsl/is_null_pointer.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_object_overview.hpp
+++ b/examples/example_is_object_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_OBJECT_OVERVIEW_HPP
-#define EXAMPLE_IS_OBJECT_OVERVIEW_HPP
-
 #include <bsl/is_object.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_pod_overview.hpp
+++ b/examples/example_is_pod_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_POD_OVERVIEW_HPP
-#define EXAMPLE_IS_POD_OVERVIEW_HPP
-
 #include <bsl/is_pod.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_pointer_overview.hpp
+++ b/examples/example_is_pointer_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_POINTER_OVERVIEW_HPP
-#define EXAMPLE_IS_POINTER_OVERVIEW_HPP
-
 #include <bsl/is_pointer.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_polymorphic_overview.hpp
+++ b/examples/example_is_polymorphic_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_POLYMORPHIC_OVERVIEW_HPP
-#define EXAMPLE_IS_POLYMORPHIC_OVERVIEW_HPP
-
 #include <bsl/is_polymorphic.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_reference_overview.hpp
+++ b/examples/example_is_reference_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_REFERENCE_OVERVIEW_HPP
-#define EXAMPLE_IS_REFERENCE_OVERVIEW_HPP
-
 #include <bsl/is_reference.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_reference_wrapper_overview.hpp
+++ b/examples/example_is_reference_wrapper_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_REFERENCE_WRAPPER_OVERVIEW_HPP
-#define EXAMPLE_IS_REFERENCE_WRAPPER_OVERVIEW_HPP
-
 #include <bsl/is_reference_wrapper.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_rvalue_reference_overview.hpp
+++ b/examples/example_is_rvalue_reference_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_RVALUE_REFERENCE_OVERVIEW_HPP
-#define EXAMPLE_IS_RVALUE_REFERENCE_OVERVIEW_HPP
-
 #include <bsl/is_rvalue_reference.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_same_overview.hpp
+++ b/examples/example_is_same_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_SAME_OVERVIEW_HPP
-#define EXAMPLE_IS_SAME_OVERVIEW_HPP
-
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_scalar_overview.hpp
+++ b/examples/example_is_scalar_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_SCALAR_OVERVIEW_HPP
-#define EXAMPLE_IS_SCALAR_OVERVIEW_HPP
-
 #include <bsl/is_scalar.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_signed_overview.hpp
+++ b/examples/example_is_signed_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_SIGNED_OVERVIEW_HPP
-#define EXAMPLE_IS_SIGNED_OVERVIEW_HPP
-
 #include <bsl/is_signed.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_standard_layout_overview.hpp
+++ b/examples/example_is_standard_layout_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_STANDARD_LAYOUT_OVERVIEW_HPP
-#define EXAMPLE_IS_STANDARD_LAYOUT_OVERVIEW_HPP
-
 #include <bsl/is_standard_layout.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_swappable_overview.hpp
+++ b/examples/example_is_swappable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_SWAPPABLE_HPP
-#define EXAMPLE_IS_SWAPPABLE_HPP
-
 #include <bsl/is_swappable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_swappable_with_overview.hpp
+++ b/examples/example_is_swappable_with_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_SWAPPABLE_WITH_HPP
-#define EXAMPLE_IS_SWAPPABLE_WITH_HPP
-
 #include <bsl/is_swappable_with.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivial_overview.hpp
+++ b/examples/example_is_trivial_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIAL_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIAL_OVERVIEW_HPP
-
 #include <bsl/is_trivial.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_assignable_overview.hpp
+++ b/examples/example_is_trivially_assignable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_ASSIGNABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_ASSIGNABLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_assignable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_constructible_overview.hpp
+++ b/examples/example_is_trivially_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_copy_assignable_overview.hpp
+++ b/examples/example_is_trivially_copy_assignable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_COPY_ASSIGNABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_COPY_ASSIGNABLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_copy_assignable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_copy_constructible_overview.hpp
+++ b/examples/example_is_trivially_copy_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_COPY_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_COPY_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_copy_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_copyable_overview.hpp
+++ b/examples/example_is_trivially_copyable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_COPYABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_COPYABLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_copyable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_default_constructible_overview.hpp
+++ b/examples/example_is_trivially_default_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_DEFAULT_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_DEFAULT_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_default_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_destructible_overview.hpp
+++ b/examples/example_is_trivially_destructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_DESTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_DESTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_destructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_movable_overview.hpp
+++ b/examples/example_is_trivially_movable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_MOVABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_MOVABLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_movable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_move_assignable_overview.hpp
+++ b/examples/example_is_trivially_move_assignable_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_MOVE_ASSIGNABLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_MOVE_ASSIGNABLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_move_assignable.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_trivially_move_constructible_overview.hpp
+++ b/examples/example_is_trivially_move_constructible_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_TRIVIALLY_MOVE_CONSTRUCTIBLE_OVERVIEW_HPP
-#define EXAMPLE_IS_TRIVIALLY_MOVE_CONSTRUCTIBLE_OVERVIEW_HPP
-
 #include <bsl/is_trivially_move_constructible.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_unbounded_array_overview.hpp
+++ b/examples/example_is_unbounded_array_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_UNBOUNDED_ARRAY_OVERVIEW_HPP
-#define EXAMPLE_IS_UNBOUNDED_ARRAY_OVERVIEW_HPP
-
 #include <bsl/is_unbounded_array.hpp>
 
 namespace bsl
@@ -40,5 +37,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_unsigned_overview.hpp
+++ b/examples/example_is_unsigned_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_UNSIGNED_OVERVIEW_HPP
-#define EXAMPLE_IS_UNSIGNED_OVERVIEW_HPP
-
 #include <bsl/is_unsigned.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_is_void_overview.hpp
+++ b/examples/example_is_void_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_IS_VOID_OVERVIEW_HPP
-#define EXAMPLE_IS_VOID_OVERVIEW_HPP
-
 #include <bsl/is_void.hpp>
 
 namespace bsl
@@ -40,5 +37,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_make_signed_overview.hpp
+++ b/examples/example_make_signed_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_MAKE_SIGNED_OVERVIEW_HPP
-#define EXAMPLE_MAKE_SIGNED_OVERVIEW_HPP
-
 #include <bsl/make_signed.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_make_unsigned_overview.hpp
+++ b/examples/example_make_unsigned_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_MAKE_UNSIGNED_OVERVIEW_HPP
-#define EXAMPLE_MAKE_UNSIGNED_OVERVIEW_HPP
-
 #include <bsl/make_unsigned.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_max_align_t_overview.hpp
+++ b/examples/example_max_align_t_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_MAX_ALIGN_T_OVERVIEW_HPP
-#define EXAMPLE_MAX_ALIGN_T_OVERVIEW_HPP
-
 #include <bsl/max_align_t.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_max_of_overview.hpp
+++ b/examples/example_max_of_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_MAX_OF_OVERVIEW_HPP
-#define EXAMPLE_MAX_OF_OVERVIEW_HPP
-
 #include <bsl/max_of.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_min_of_overview.hpp
+++ b/examples/example_min_of_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_MIN_OF_OVERVIEW_HPP
-#define EXAMPLE_MIN_OF_OVERVIEW_HPP
-
 #include <bsl/min_of.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_move_if_noexcept_overview.hpp
+++ b/examples/example_move_if_noexcept_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_MOVE_IF_NOEXCEPT_OVERVIEW_HPP
-#define EXAMPLE_MOVE_IF_NOEXCEPT_OVERVIEW_HPP
-
 #include <bsl/move_if_noexcept.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_move_overview.hpp
+++ b/examples/example_move_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_MOVE_OVERVIEW_HPP
-#define EXAMPLE_MOVE_OVERVIEW_HPP
-
 #include <bsl/move.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_negation_overview.hpp
+++ b/examples/example_negation_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_NEGATION_OVERVIEW_HPP
-#define EXAMPLE_NEGATION_OVERVIEW_HPP
-
 #include <bsl/negation.hpp>
 #include <bsl/is_bool.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_numeric_limits_overview.hpp
+++ b/examples/example_numeric_limits_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_NUMERIC_LIMITS_OVERVIEW_HPP
-#define EXAMPLE_NUMERIC_LIMITS_OVERVIEW_HPP
-
 #include <bsl/numeric_limits.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_rank_overview.hpp
+++ b/examples/example_rank_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RANK_OVERVIEW_HPP
-#define EXAMPLE_RANK_OVERVIEW_HPP
-
 #include <bsl/rank.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_reference_wrapper_overview.hpp
+++ b/examples/example_reference_wrapper_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REFERENCE_WRAPPER_OVERVIEW_HPP
-#define EXAMPLE_REFERENCE_WRAPPER_OVERVIEW_HPP
-
 #include <bsl/reference_wrapper.hpp>
 #include <bsl/debug.hpp>
 
@@ -47,5 +44,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_remove_all_extents_overview.hpp
+++ b/examples/example_remove_all_extents_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REMOVE_ALL_EXTENTS_OVERVIEW_HPP
-#define EXAMPLE_REMOVE_ALL_EXTENTS_OVERVIEW_HPP
-
 #include <bsl/remove_all_extents.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_remove_const_overview.hpp
+++ b/examples/example_remove_const_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REMOVE_CONST_OVERVIEW_HPP
-#define EXAMPLE_REMOVE_CONST_OVERVIEW_HPP
-
 #include <bsl/remove_const.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_remove_cv_overview.hpp
+++ b/examples/example_remove_cv_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REMOVE_CV_OVERVIEW_HPP
-#define EXAMPLE_REMOVE_CV_OVERVIEW_HPP
-
 #include <bsl/remove_cv.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_remove_cvext_overview.hpp
+++ b/examples/example_remove_cvext_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REMOVE_CVEXT_OVERVIEW_HPP
-#define EXAMPLE_REMOVE_CVEXT_OVERVIEW_HPP
-
 #include <bsl/remove_cvext.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_remove_cvref_overview.hpp
+++ b/examples/example_remove_cvref_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REMOVE_CVREF_OVERVIEW_HPP
-#define EXAMPLE_REMOVE_CVREF_OVERVIEW_HPP
-
 #include <bsl/remove_cvref.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_remove_extent_overview.hpp
+++ b/examples/example_remove_extent_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REMOVE_EXTENT_OVERVIEW_HPP
-#define EXAMPLE_REMOVE_EXTENT_OVERVIEW_HPP
-
 #include <bsl/remove_extent.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_remove_pointer_overview.hpp
+++ b/examples/example_remove_pointer_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REMOVE_POINTER_OVERVIEW_HPP
-#define EXAMPLE_REMOVE_POINTER_OVERVIEW_HPP
-
 #include <bsl/remove_pointer.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_remove_reference_overview.hpp
+++ b/examples/example_remove_reference_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REMOVE_REFERENCE_OVERVIEW_HPP
-#define EXAMPLE_REMOVE_REFERENCE_OVERVIEW_HPP
-
 #include <bsl/remove_reference.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_result_overview.hpp
+++ b/examples/example_result_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_OVERVIEW_HPP
-#define EXAMPLE_RESULT_OVERVIEW_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_reverse_iterator_overview.hpp
+++ b/examples/example_reverse_iterator_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_OVERVIEW_HPP
-#define EXAMPLE_REVERSE_ITERATOR_OVERVIEW_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/for_each.hpp>
 #include <bsl/debug.hpp>
@@ -45,5 +42,3 @@ namespace bsl
         bsl::print() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/example_source_location_overview.hpp
+++ b/examples/example_source_location_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SOURCE_LOCATION_OVERVIEW_HPP
-#define EXAMPLE_SOURCE_LOCATION_OVERVIEW_HPP
-
 #include <bsl/source_location.hpp>
 #include <bsl/debug.hpp>
 
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << bsl::here();
     }
 }
-
-#endif

--- a/examples/example_span_overview.hpp
+++ b/examples/example_span_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_OVERVIEW_HPP
-#define EXAMPLE_SPAN_OVERVIEW_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -54,5 +51,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/example_swap_overview.hpp
+++ b/examples/example_swap_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SWAP_OVERVIEW_HPP
-#define EXAMPLE_SWAP_OVERVIEW_HPP
-
 #include <bsl/swap.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_true_type_overview.hpp
+++ b/examples/example_true_type_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_TRUE_TYPE_OVERVIEW_HPP
-#define EXAMPLE_TRUE_TYPE_OVERVIEW_HPP
-
 #include <bsl/true_type.hpp>
 #include <bsl/debug.hpp>
 
@@ -41,5 +38,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_underlying_type_overview.hpp
+++ b/examples/example_underlying_type_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_UNDERLYING_TYPE_OVERVIEW_HPP
-#define EXAMPLE_UNDERLYING_TYPE_OVERVIEW_HPP
-
 #include <bsl/underlying_type.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/example_void_t_overview.hpp
+++ b/examples/example_void_t_overview.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_VOID_T_OVERVIEW_HPP
-#define EXAMPLE_VOID_T_OVERVIEW_HPP
-
 #include <bsl/void_t.hpp>
 #include <bsl/is_same.hpp>
 #include <bsl/debug.hpp>
@@ -42,5 +39,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_align.hpp
+++ b/examples/fmt/example_fmt_align.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_ALIGN_HPP
-#define EXAMPLE_FMT_ALIGN_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -46,5 +43,3 @@ namespace bsl
         bsl::print() << bsl::fmt{"_<30", '_'} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_alt_form.hpp
+++ b/examples/fmt/example_fmt_alt_form.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_ALT_FORM_HPP
-#define EXAMPLE_FMT_ALT_FORM_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -41,5 +38,3 @@ namespace bsl
         bsl::print() << bsl::fmt{"#x", val} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_bool.hpp
+++ b/examples/fmt/example_fmt_bool.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_BOOL_HPP
-#define EXAMPLE_FMT_BOOL_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -41,5 +38,3 @@ namespace bsl
         bsl::print() << bsl::fmt{"d", false} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_char_type.hpp
+++ b/examples/fmt/example_fmt_char_type.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_CHAR_TYPE_HPP
-#define EXAMPLE_FMT_CHAR_TYPE_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -42,5 +39,3 @@ namespace bsl
         bsl::print() << bsl::fmt{"x", val} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_constructor_f_val.hpp
+++ b/examples/fmt/example_fmt_constructor_f_val.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_CONSTRUCTOR_F_VAL_HPP
-#define EXAMPLE_FMT_CONSTRUCTOR_F_VAL_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << bsl::fmt{".<42", '.'} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_constructor_f_val_width.hpp
+++ b/examples/fmt/example_fmt_constructor_f_val_width.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_CONSTRUCTOR_F_VAL_WIDTH_HPP
-#define EXAMPLE_FMT_CONSTRUCTOR_F_VAL_WIDTH_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -41,5 +38,3 @@ namespace bsl
         bsl::print() << bsl::fmt{".<", '.', width2} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_cstr_type.hpp
+++ b/examples/fmt/example_fmt_cstr_type.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_CSTR_TYPE_HPP
-#define EXAMPLE_FMT_CSTR_TYPE_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -38,5 +35,3 @@ namespace bsl
         bsl::print() << bsl::fmt{"", "success"} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_integral.hpp
+++ b/examples/fmt/example_fmt_integral.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_INTREGRAL_HPP
-#define EXAMPLE_FMT_INTREGRAL_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -56,5 +53,3 @@ namespace bsl
         bsl::print() << bsl::fmt{"-", val2} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_sign.hpp
+++ b/examples/fmt/example_fmt_sign.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_SIGN_HPP
-#define EXAMPLE_FMT_SIGN_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -46,5 +43,3 @@ namespace bsl
         bsl::print() << bsl::fmt{" ", val2} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_sign_aware.hpp
+++ b/examples/fmt/example_fmt_sign_aware.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_SIGN_AWARE_HPP
-#define EXAMPLE_FMT_SIGN_AWARE_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -42,5 +39,3 @@ namespace bsl
         bsl::print() << bsl::fmt{"#010x", val} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/fmt/example_fmt_width.hpp
+++ b/examples/fmt/example_fmt_width.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_FMT_WIDTH_HPP
-#define EXAMPLE_FMT_WIDTH_HPP
-
 #include <bsl/debug.hpp>
 
 namespace bsl
@@ -47,5 +44,3 @@ namespace bsl
         bsl::print() << bsl::fmt{"#0x", val, width} << bsl::endl;
     }
 }
-
-#endif

--- a/examples/integer_sequence/example_integer_sequence_max.hpp
+++ b/examples/integer_sequence/example_integer_sequence_max.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_INTEGER_SEQUENCE_MAX_HPP
-#define EXAMPLE_INTEGER_SEQUENCE_MAX_HPP
-
 #include <bsl/integer_sequence.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/integer_sequence/example_integer_sequence_min.hpp
+++ b/examples/integer_sequence/example_integer_sequence_min.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_INTEGER_SEQUENCE_MIN_HPP
-#define EXAMPLE_INTEGER_SEQUENCE_MIN_HPP
-
 #include <bsl/integer_sequence.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/integer_sequence/example_integer_sequence_size.hpp
+++ b/examples/integer_sequence/example_integer_sequence_size.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_INTEGER_SEQUENCE_SIZE_HPP
-#define EXAMPLE_INTEGER_SEQUENCE_SIZE_HPP
-
 #include <bsl/integer_sequence.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reference_wrapper/example_reference_wrapper_constructor.hpp
+++ b/examples/reference_wrapper/example_reference_wrapper_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REFERENCE_WRAPPER_CONSTRUCTOR_HPP
-#define EXAMPLE_REFERENCE_WRAPPER_CONSTRUCTOR_HPP
-
 #include <bsl/reference_wrapper.hpp>
 #include <bsl/debug.hpp>
 
@@ -47,5 +44,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reference_wrapper/example_reference_wrapper_functor.hpp
+++ b/examples/reference_wrapper/example_reference_wrapper_functor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REFERENCE_WRAPPER_FUNCTOR_HPP
-#define EXAMPLE_REFERENCE_WRAPPER_FUNCTOR_HPP
-
 #include <bsl/reference_wrapper.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reference_wrapper/example_reference_wrapper_get.hpp
+++ b/examples/reference_wrapper/example_reference_wrapper_get.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REFERENCE_WRAPPER_GET_HPP
-#define EXAMPLE_REFERENCE_WRAPPER_GET_HPP
-
 #include <bsl/reference_wrapper.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_copy_assignment.hpp
+++ b/examples/result/example_result_copy_assignment.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_COPY_ASSIGNMENT_HPP
-#define EXAMPLE_RESULT_COPY_ASSIGNMENT_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_copy_constructor.hpp
+++ b/examples/result/example_result_copy_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_COPY_CONSTRUCTOR_HPP
-#define EXAMPLE_RESULT_COPY_CONSTRUCTOR_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_equals.hpp
+++ b/examples/result/example_result_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_EQUALS_HPP
-#define EXAMPLE_RESULT_EQUALS_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_errc.hpp
+++ b/examples/result/example_result_errc.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_ERRC_HPP
-#define EXAMPLE_RESULT_ERRC_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_errc_copy_constructor.hpp
+++ b/examples/result/example_result_errc_copy_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_ERRC_COPY_CONSTRUCTOR_HPP
-#define EXAMPLE_RESULT_ERRC_COPY_CONSTRUCTOR_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_errc_move_constructor.hpp
+++ b/examples/result/example_result_errc_move_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_ERRC_MOVE_CONSTRUCTOR_HPP
-#define EXAMPLE_RESULT_ERRC_MOVE_CONSTRUCTOR_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -48,5 +45,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_failure.hpp
+++ b/examples/result/example_result_failure.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_FAILURE_HPP
-#define EXAMPLE_RESULT_FAILURE_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_get_if.hpp
+++ b/examples/result/example_result_get_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_GET_IF_HPP
-#define EXAMPLE_RESULT_GET_IF_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_move_assignment.hpp
+++ b/examples/result/example_result_move_assignment.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_MOVE_ASSIGNMENT_HPP
-#define EXAMPLE_RESULT_MOVE_ASSIGNMENT_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_move_constructor.hpp
+++ b/examples/result/example_result_move_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_MOVE_CONSTRUCTOR_HPP
-#define EXAMPLE_RESULT_MOVE_CONSTRUCTOR_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_not_equals.hpp
+++ b/examples/result/example_result_not_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_NOT_EQUALS_HPP
-#define EXAMPLE_RESULT_NOT_EQUALS_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -49,5 +46,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_success.hpp
+++ b/examples/result/example_result_success.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_SUCCESS_HPP
-#define EXAMPLE_RESULT_SUCCESS_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_t_copy_constructor.hpp
+++ b/examples/result/example_result_t_copy_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_T_COPY_CONSTRUCTOR_HPP
-#define EXAMPLE_RESULT_T_COPY_CONSTRUCTOR_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_t_in_place_constructor.hpp
+++ b/examples/result/example_result_t_in_place_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_T_IN_PLACE_CONSTRUCTOR_HPP
-#define EXAMPLE_RESULT_T_IN_PLACE_CONSTRUCTOR_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/result/example_result_t_move_constructor.hpp
+++ b/examples/result/example_result_t_move_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_RESULT_T_MOVE_CONSTRUCTOR_HPP
-#define EXAMPLE_RESULT_T_MOVE_CONSTRUCTOR_HPP
-
 #include <bsl/result.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_data.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_data.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_DATA_HPP
-#define EXAMPLE_REVERSE_ITERATOR_DATA_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_decrement.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_decrement.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_DECREMENT_HPP
-#define EXAMPLE_REVERSE_ITERATOR_DECREMENT_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_empty.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_empty.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_EMPTY_HPP
-#define EXAMPLE_REVERSE_ITERATOR_EMPTY_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_equals.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_EQUALS_HPP
-#define EXAMPLE_REVERSE_ITERATOR_EQUALS_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_get_if.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_get_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_GET_IF_HPP
-#define EXAMPLE_REVERSE_ITERATOR_GET_IF_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_gt.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_gt.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_GT_HPP
-#define EXAMPLE_REVERSE_ITERATOR_GT_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_gt_equals.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_gt_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_GT_EQUALS_HPP
-#define EXAMPLE_REVERSE_ITERATOR_GT_EQUALS_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_increment.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_increment.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_INCREMENT_HPP
-#define EXAMPLE_REVERSE_ITERATOR_INCREMENT_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -45,5 +42,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_index.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_index.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_INDEX_HPP
-#define EXAMPLE_REVERSE_ITERATOR_INDEX_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_is_end.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_is_end.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_IS_END_HPP
-#define EXAMPLE_REVERSE_ITERATOR_IS_END_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_lt.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_lt.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_LT_HPP
-#define EXAMPLE_REVERSE_ITERATOR_LT_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_lt_equals.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_lt_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_LT_EQUALS_HPP
-#define EXAMPLE_REVERSE_ITERATOR_LT_EQUALS_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_not_equals.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_not_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_NOT_EQUALS_HPP
-#define EXAMPLE_REVERSE_ITERATOR_NOT_EQUALS_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -66,5 +63,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/reverse_iterator/example_reverse_iterator_size.hpp
+++ b/examples/reverse_iterator/example_reverse_iterator_size.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_REVERSE_ITERATOR_SIZE_HPP
-#define EXAMPLE_REVERSE_ITERATOR_SIZE_HPP
-
 #include <bsl/string_view.hpp>
 #include <bsl/debug.hpp>
 
@@ -44,5 +41,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/source_location/example_source_location_current.hpp
+++ b/examples/source_location/example_source_location_current.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SOURCE_LOCATION_CURRENT_HPP
-#define EXAMPLE_SOURCE_LOCATION_CURRENT_HPP
-
 #include <bsl/source_location.hpp>
 #include <bsl/debug.hpp>
 
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << bsl::sloc_type::current();
     }
 }
-
-#endif

--- a/examples/source_location/example_source_location_default_constructor.hpp
+++ b/examples/source_location/example_source_location_default_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SOURCE_LOCATION_DEFAULT_CONSTRUCTOR_HPP
-#define EXAMPLE_SOURCE_LOCATION_DEFAULT_CONSTRUCTOR_HPP
-
 #include <bsl/source_location.hpp>
 #include <bsl/debug.hpp>
 
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << bsl::sloc_type{};
     }
 }
-
-#endif

--- a/examples/source_location/example_source_location_file_name.hpp
+++ b/examples/source_location/example_source_location_file_name.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SOURCE_LOCATION_FILE_NAME_HPP
-#define EXAMPLE_SOURCE_LOCATION_FILE_NAME_HPP
-
 #include <bsl/source_location.hpp>
 #include <bsl/debug.hpp>
 
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << "success: " << bsl::here().file_name() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/source_location/example_source_location_function_name.hpp
+++ b/examples/source_location/example_source_location_function_name.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SOURCE_LOCATION_FUNCTION_NAME_HPP
-#define EXAMPLE_SOURCE_LOCATION_FUNCTION_NAME_HPP
-
 #include <bsl/source_location.hpp>
 #include <bsl/debug.hpp>
 
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << "success: " << bsl::here().function_name() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/source_location/example_source_location_here.hpp
+++ b/examples/source_location/example_source_location_here.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SOURCE_LOCATION_HERE_HPP
-#define EXAMPLE_SOURCE_LOCATION_HERE_HPP
-
 #include <bsl/source_location.hpp>
 #include <bsl/debug.hpp>
 
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << bsl::here();
     }
 }
-
-#endif

--- a/examples/source_location/example_source_location_line.hpp
+++ b/examples/source_location/example_source_location_line.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SOURCE_LOCATION_LINE_HPP
-#define EXAMPLE_SOURCE_LOCATION_LINE_HPP
-
 #include <bsl/source_location.hpp>
 #include <bsl/debug.hpp>
 
@@ -39,5 +36,3 @@ namespace bsl
         bsl::print() << "success: " << bsl::here().line() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/span/example_span_at_if.hpp
+++ b/examples/span/example_span_at_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_AT_IF_HPP
-#define EXAMPLE_SPAN_AT_IF_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -53,5 +50,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_back_if.hpp
+++ b/examples/span/example_span_back_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_BACK_IF_HPP
-#define EXAMPLE_SPAN_BACK_IF_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -53,5 +50,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_begin.hpp
+++ b/examples/span/example_span_begin.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_BEGIN_HPP
-#define EXAMPLE_SPAN_BEGIN_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -54,5 +51,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/span/example_span_data.hpp
+++ b/examples/span/example_span_data.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_DATA_HPP
-#define EXAMPLE_SPAN_DATA_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -53,5 +50,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_default_constructor.hpp
+++ b/examples/span/example_span_default_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_DEFAULT_CONSTRUCTOR_HPP
-#define EXAMPLE_SPAN_DEFAULT_CONSTRUCTOR_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/debug.hpp>
 
@@ -43,5 +40,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_empty.hpp
+++ b/examples/span/example_span_empty.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_EMPTY_HPP
-#define EXAMPLE_SPAN_EMPTY_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -53,5 +50,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_end.hpp
+++ b/examples/span/example_span_end.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_END_HPP
-#define EXAMPLE_SPAN_END_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -54,5 +51,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/span/example_span_equals.hpp
+++ b/examples/span/example_span_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_EQUALS_HPP
-#define EXAMPLE_SPAN_EQUALS_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -61,5 +58,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_first.hpp
+++ b/examples/span/example_span_first.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_FIRST_HPP
-#define EXAMPLE_SPAN_FIRST_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -63,5 +60,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_front_if.hpp
+++ b/examples/span/example_span_front_if.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_FRONT_IF_HPP
-#define EXAMPLE_SPAN_FRONT_IF_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -53,5 +50,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_iter.hpp
+++ b/examples/span/example_span_iter.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_ITER_HPP
-#define EXAMPLE_SPAN_ITER_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -57,5 +54,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/span/example_span_last.hpp
+++ b/examples/span/example_span_last.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_LAST_HPP
-#define EXAMPLE_SPAN_LAST_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -58,5 +55,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_max_size.hpp
+++ b/examples/span/example_span_max_size.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_MAX_SIZE_HPP
-#define EXAMPLE_SPAN_MAX_SIZE_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -51,5 +48,3 @@ namespace bsl
         bsl::print() << "max size: " << spn.max_size() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/span/example_span_not_equals.hpp
+++ b/examples/span/example_span_not_equals.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_NOT_EQUALS_HPP
-#define EXAMPLE_SPAN_NOT_EQUALS_HPP
-
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
 
@@ -61,5 +58,3 @@ namespace bsl
         }
     }
 }
-
-#endif

--- a/examples/span/example_span_ptr_count_constructor.hpp
+++ b/examples/span/example_span_ptr_count_constructor.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_PTR_COUNT_CONSTRUCTOR_HPP
-#define EXAMPLE_SPAN_PTR_COUNT_CONSTRUCTOR_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -54,5 +51,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/span/example_span_rbegin.hpp
+++ b/examples/span/example_span_rbegin.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_RBEGIN_HPP
-#define EXAMPLE_SPAN_RBEGIN_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -54,5 +51,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/span/example_span_rend.hpp
+++ b/examples/span/example_span_rend.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_REND_HPP
-#define EXAMPLE_SPAN_REND_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -54,5 +51,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/span/example_span_riter.hpp
+++ b/examples/span/example_span_riter.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_RITER_HPP
-#define EXAMPLE_SPAN_RITER_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -57,5 +54,3 @@ namespace bsl
         });
     }
 }
-
-#endif

--- a/examples/span/example_span_size.hpp
+++ b/examples/span/example_span_size.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_SIZE_HPP
-#define EXAMPLE_SPAN_SIZE_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -51,5 +48,3 @@ namespace bsl
         bsl::print() << "size: " << spn.size() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/span/example_span_size_bytes.hpp
+++ b/examples/span/example_span_size_bytes.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_SIZE_BYTES_HPP
-#define EXAMPLE_SPAN_SIZE_BYTES_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/debug.hpp>
@@ -51,5 +48,3 @@ namespace bsl
         bsl::print() << "size in bytes: " << spn.size_bytes() << bsl::endl;
     }
 }
-
-#endif

--- a/examples/span/example_span_subspan.hpp
+++ b/examples/span/example_span_subspan.hpp
@@ -22,9 +22,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#ifndef EXAMPLE_SPAN_SUBSPAN_HPP
-#define EXAMPLE_SPAN_SUBSPAN_HPP
-
 #include <bsl/span.hpp>
 #include <bsl/array.hpp>
 #include <bsl/for_each.hpp>
@@ -65,5 +62,3 @@ namespace bsl
         }
     }
 }
-
-#endif


### PR DESCRIPTION
This patch removes the include guards on the examples as they are
not required, and it will clean up the examples in the docs.