### PR TITLE
Move verbosity to the info target

### DIFF
--- a/cmake/config/all_projects.cmake
+++ b/cmake/config/all_projects.cmake
@@ -79,8 +79,6 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL RELEASE AND
     message(FATAL_ERROR "Unknown CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 endif()
 
-message(STATUS "Build type: ${BF_COLOR_CYN}${CMAKE_BUILD_TYPE}${BF_COLOR_RST}")
-
 # ------------------------------------------------------------------------------
 # validate
 # ------------------------------------------------------------------------------
@@ -146,7 +144,7 @@ set(BF_COLOR_WHT "${Esc}[97m")
 # ------------------------------------------------------------------------------
 
 set(BF_ENABLED "${BF_COLOR_GRN}enabled${BF_COLOR_RST}")
-set(BF_DISABLED "${BF_COLOR_YLW}disabled${BF_COLOR_RST}")
+set(BF_DISABLED "${BF_COLOR_RED}disabled${BF_COLOR_RST}")
 
 # ------------------------------------------------------------------------------
 # build command
@@ -161,90 +159,35 @@ else()
 endif()
 
 # ------------------------------------------------------------------------------
-# examples
-# ------------------------------------------------------------------------------
-
-if(BUILD_EXAMPLES)
-    message(STATUS "Build examples: ${BF_ENABLED}")
-else()
-    message(STATUS "Build examples: ${BF_DISABLED}")
-endif()
-
-# ------------------------------------------------------------------------------
 # tests
 # ------------------------------------------------------------------------------
 
 if(BUILD_TESTS)
     include(CTest)
-    message(STATUS "Build tests: ${BF_ENABLED}")
-else()
-    message(STATUS "Build tests: ${BF_DISABLED}")
 endif()
 
 # ------------------------------------------------------------------------------
-# clang tidy
-# ------------------------------------------------------------------------------
-
-if(CMAKE_BUILD_TYPE STREQUAL CLANG_TIDY)
-    bf_find_program(CMAKE_CXX_CLANG_TIDY "clang-tidy" "https://clang.llvm.org/extra/clang-tidy/")
-    message(STATUS "Tool [Clang Tidy]: ${BF_ENABLED} - ${CMAKE_CXX_CLANG_TIDY}")
-endif()
-
-# ------------------------------------------------------------------------------
-# clang format
+# find programs
 # ------------------------------------------------------------------------------
 
 if(ENABLE_CLANG_FORMAT)
     bf_find_program(BF_CLANG_FORMAT "clang-format" "https://clang.llvm.org/docs/ClangFormat.html")
-    message(STATUS "Tool [Clang Format]: ${BF_ENABLED} - ${BF_CLANG_FORMAT}")
-else()
-    message(STATUS "Tool [Clang Format]: ${BF_DISABLED}")
 endif()
-
-# ------------------------------------------------------------------------------
-# grcov
-# ------------------------------------------------------------------------------
-
-if(CMAKE_BUILD_TYPE STREQUAL CODECOV)
-    bf_find_program(BF_GRCOV "grcov" "https://github.com/mozilla/grcov")
-    message(STATUS "Tool [grcov]: ${BF_ENABLED} - ${BF_GRCOV}")
-else()
-    message(STATUS "Tool [grcov]: ${BF_DISABLED}")
-endif()
-
-# ------------------------------------------------------------------------------
-# doxygen
-# ------------------------------------------------------------------------------
 
 if(ENABLE_DOXYGEN)
     bf_find_program(BF_DOXYGEN "doxygen" "http://doxygen.nl/")
-    message(STATUS "Tool [Doxygen]: ${BF_ENABLED} - ${BF_DOXYGEN}")
-else()
-    message(STATUS "Tool [Doxygen]: ${BF_DISABLED}")
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL CLANG_TIDY)
+    bf_find_program(CMAKE_CXX_CLANG_TIDY "clang-tidy" "https://clang.llvm.org/extra/clang-tidy/")
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL CODECOV)
+    bf_find_program(BF_GRCOV "grcov" "https://github.com/mozilla/grcov")
 endif()
 
 # ------------------------------------------------------------------------------
-# asan
-# ------------------------------------------------------------------------------
-
-if(CMAKE_BUILD_TYPE STREQUAL ASAN)
-    message(STATUS "Tool [Google's ASAN]: ${BF_ENABLED}")
-else()
-    message(STATUS "Tool [Google's ASAN]: ${BF_DISABLED}")
-endif()
-
-# ------------------------------------------------------------------------------
-# ubsan
-# ------------------------------------------------------------------------------
-
-if(CMAKE_BUILD_TYPE STREQUAL UBSAN)
-    message(STATUS "Tool [Google's UBSAN]: ${BF_ENABLED}")
-else()
-    message(STATUS "Tool [Google's UBSAN]: ${BF_DISABLED}")
-endif()
-
-# ------------------------------------------------------------------------------
-# defaults
+# perforce
 # ------------------------------------------------------------------------------
 
 if(CMAKE_BUILD_TYPE STREQUAL PERFORCE)
@@ -288,5 +231,3 @@ set(CMAKE_CXX_FLAGS_UBSAN "-Og -g -fsanitize=undefined ${BSL_WARNINGS}")
 set(CMAKE_LINKER_FLAGS_UBSAN "-Og -g -fsanitize=undefined ${BSL_WARNINGS}")
 set(CMAKE_CXX_FLAGS_CODECOV "-O0 -fprofile-arcs -ftest-coverage ${BSL_WARNINGS}")
 set(CMAKE_LINKER_FLAGS_CODECOV "-O0 -fprofile-arcs -ftest-coverage ${BSL_WARNINGS}")
-
-message(STATUS "CXX Flags:${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")

--- a/cmake/target/info.cmake
+++ b/cmake/target/info.cmake
@@ -32,27 +32,112 @@ add_custom_command(TARGET info
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --green   " Please give us a star on: ${BF_COLOR_WHT}https://github.com/Bareflank "
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --blue    " ------------------------------------------------------ "
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color " "
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --green   " Current Build Configuration:"
     VERBATIM
 )
 
+# ------------------------------------------------------------------------------
+# options
+# ------------------------------------------------------------------------------
+
+if(BUILD_EXAMPLES)
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BUILD_EXAMPLES                 ${BF_ENABLED}"
+        VERBATIM
+    )
+else()
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BUILD_EXAMPLES                 ${BF_DISABLED}"
+        VERBATIM
+    )
+endif()
+
+if(BUILD_TESTS)
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BUILD_TESTS                    ${BF_ENABLED}"
+        VERBATIM
+    )
+else()
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BUILD_TESTS                    ${BF_DISABLED}"
+        VERBATIM
+    )
+endif()
+
+if(ENABLE_CLANG_FORMAT)
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ENABLE_CLANG_FORMAT            ${BF_ENABLED} - ${BF_CLANG_FORMAT}"
+        VERBATIM
+    )
+else()
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ENABLE_CLANG_FORMAT            ${BF_DISABLED}"
+        VERBATIM
+    )
+endif()
+
+if(ENABLE_DOXYGEN)
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ENABLE_DOXYGEN                 ${BF_ENABLED} - ${BF_DOXYGEN}"
+        VERBATIM
+    )
+else()
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ENABLE_DOXYGEN                 ${BF_DISABLED}"
+        VERBATIM
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# settings
+# ------------------------------------------------------------------------------
+
 add_custom_command(TARGET info
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --green   " Supported CMake Build Types:"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   -DCMAKE_BUILD_TYPE=RELEASE            compile in release mode"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   -DCMAKE_BUILD_TYPE=DEBUG              compile in debug mode"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   -DCMAKE_BUILD_TYPE=CLANG_TIDY         compile with Clang Tidy checks"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   -DCMAKE_BUILD_TYPE=PERFORCE           compile with Perforce checks"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   -DCMAKE_BUILD_TYPE=ASAN               compile with Google ASAN"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   -DCMAKE_BUILD_TYPE=UBSAN              compile with Google UBSAN"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   -DCMAKE_BUILD_TYPE=CODECOV            compile with LLVM coverage"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BSL_DEBUG_LEVEL                ${BF_COLOR_CYN}${BSL_DEBUG_LEVEL}"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BSL_PAGE_SIZE                  ${BF_COLOR_CYN}${BSL_PAGE_SIZE}"
+    VERBATIM
+)
+
+# ------------------------------------------------------------------------------
+# build type
+# ------------------------------------------------------------------------------
+
+if(CMAKE_BUILD_TYPE STREQUAL CLANG_TIDY)
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   CMAKE_BUILD_TYPE               ${BF_COLOR_CYN}${CMAKE_BUILD_TYPE}${BF_COLOR_RST} - ${CMAKE_CXX_CLANG_TIDY}"
+        VERBATIM
+    )
+elseif(CMAKE_BUILD_TYPE STREQUAL CODECOV)
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   CMAKE_BUILD_TYPE               ${BF_COLOR_CYN}${CMAKE_BUILD_TYPE}${BF_COLOR_RST} - ${BF_GRCOV}"
+        VERBATIM
+    )
+else()
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   CMAKE_BUILD_TYPE               ${BF_COLOR_CYN}${CMAKE_BUILD_TYPE}"
+        VERBATIM
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# remaining info
+# ------------------------------------------------------------------------------
+
+add_custom_command(TARGET info
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color " "
-    VERBATIM
-)
-
-add_custom_command(TARGET info
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --green   " Supported CMake Build Types:"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "  -DCMAKE_BUILD_TYPE=RELEASE      compile in release mode"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "  -DCMAKE_BUILD_TYPE=DEBUG        compile in debug mode"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "  -DCMAKE_BUILD_TYPE=CLANG_TIDY   compile with Clang Tidy checks"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "  -DCMAKE_BUILD_TYPE=PERFORCE     compile with Perforce checks"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "  -DCMAKE_BUILD_TYPE=ASAN         compile with Google ASAN"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "  -DCMAKE_BUILD_TYPE=UBSAN        compile with Google UBSAN"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "  -DCMAKE_BUILD_TYPE=CODECOV      compile with LLVM coverage"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color " "
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --green   " Basic Commands:"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} info                            shows this help info"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND}                                 builds the project"
-    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} clean                           cleans the project"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} info                     shows this help info"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND}                          builds the project"
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} clean                    cleans the project"
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color " "
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --green   " Supported Build Targets:"
     VERBATIM
@@ -60,41 +145,29 @@ add_custom_command(TARGET info
 
 if(BUILD_TESTS)
     add_custom_command(TARGET info
-        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} unittest                        run the project's unit tests"
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} unittest                 run the project's unit tests"
         VERBATIM
     )
 endif()
-
-# ------------------------------------------------------------------------------
-# clang format
-# ------------------------------------------------------------------------------
 
 if(ENABLE_CLANG_FORMAT)
     add_custom_command(TARGET info
-        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} format                          formats the source code"
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} format                   formats the source code"
         VERBATIM
     )
 endif()
-
-# ------------------------------------------------------------------------------
-# llvm-cov
-# ------------------------------------------------------------------------------
-
-if(CMAKE_BUILD_TYPE STREQUAL CODECOV)
-    add_custom_command(TARGET info
-        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} codecov-info                   gathers info about unit test coverage"
-        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} codecov-upload                 uploads results of unit test coverage"
-        VERBATIM
-    )
-endif()
-
-# ------------------------------------------------------------------------------
-# doxygen
-# ------------------------------------------------------------------------------
 
 if(ENABLE_DOXYGEN)
     add_custom_command(TARGET info
-        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} doxygen                         generates documentation"
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} doxygen                  generates documentation"
+        VERBATIM
+    )
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL CODECOV)
+    add_custom_command(TARGET info
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} codecov-info            gathers info about unit test coverage"
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} codecov-upload          uploads results of unit test coverage"
         VERBATIM
     )
 endif()


### PR DESCRIPTION
This patch moves some of the verbosity of the bsl build system
to the info target so that you can still get the build
connfiguration, but it is not duplicated with FetchContent