### PR TITLE
Ensure the info target can be added to

### DIFF
--- a/cmake/target/info.cmake
+++ b/cmake/target/info.cmake
@@ -19,11 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-add_custom_target(
-    info
-)
+add_custom_target(BSL_INFO_TARGET)
 
-add_custom_command(TARGET info
+add_custom_command(TARGET BSL_INFO_TARGET
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --magenta "  ___   _   ___ ___ ___ _      _   _  _ _  __ "
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --magenta " | _ ) /_\\ | _ \\ __| __| |    /_\\ | \\| | |/ / "
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --magenta " | _ \\/ _ \\|   / _|| _|| |__ / _ \\| .` | ' <  "
@@ -41,48 +39,48 @@ add_custom_command(TARGET info
 # ------------------------------------------------------------------------------
 
 if(BUILD_EXAMPLES)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BUILD_EXAMPLES                 ${BF_ENABLED}"
         VERBATIM
     )
 else()
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BUILD_EXAMPLES                 ${BF_DISABLED}"
         VERBATIM
     )
 endif()
 
 if(BUILD_TESTS)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BUILD_TESTS                    ${BF_ENABLED}"
         VERBATIM
     )
 else()
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BUILD_TESTS                    ${BF_DISABLED}"
         VERBATIM
     )
 endif()
 
 if(ENABLE_CLANG_FORMAT)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ENABLE_CLANG_FORMAT            ${BF_ENABLED} - ${BF_CLANG_FORMAT}"
         VERBATIM
     )
 else()
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ENABLE_CLANG_FORMAT            ${BF_DISABLED}"
         VERBATIM
     )
 endif()
 
 if(ENABLE_DOXYGEN)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ENABLE_DOXYGEN                 ${BF_ENABLED} - ${BF_DOXYGEN}"
         VERBATIM
     )
 else()
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ENABLE_DOXYGEN                 ${BF_DISABLED}"
         VERBATIM
     )
@@ -92,7 +90,7 @@ endif()
 # settings
 # ------------------------------------------------------------------------------
 
-add_custom_command(TARGET info
+add_custom_command(TARGET BSL_INFO_TARGET
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BSL_DEBUG_LEVEL                ${BF_COLOR_CYN}${BSL_DEBUG_LEVEL}"
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   BSL_PAGE_SIZE                  ${BF_COLOR_CYN}${BSL_PAGE_SIZE}"
     VERBATIM
@@ -103,17 +101,17 @@ add_custom_command(TARGET info
 # ------------------------------------------------------------------------------
 
 if(CMAKE_BUILD_TYPE STREQUAL CLANG_TIDY)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   CMAKE_BUILD_TYPE               ${BF_COLOR_CYN}${CMAKE_BUILD_TYPE}${BF_COLOR_RST} - ${CMAKE_CXX_CLANG_TIDY}"
         VERBATIM
     )
 elseif(CMAKE_BUILD_TYPE STREQUAL CODECOV)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   CMAKE_BUILD_TYPE               ${BF_COLOR_CYN}${CMAKE_BUILD_TYPE}${BF_COLOR_RST} - ${BF_GRCOV}"
         VERBATIM
     )
 else()
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   CMAKE_BUILD_TYPE               ${BF_COLOR_CYN}${CMAKE_BUILD_TYPE}"
         VERBATIM
     )
@@ -123,7 +121,7 @@ endif()
 # remaining info
 # ------------------------------------------------------------------------------
 
-add_custom_command(TARGET info
+add_custom_command(TARGET BSL_INFO_TARGET
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color " "
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --green   " Supported CMake Build Types:"
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "  -DCMAKE_BUILD_TYPE=RELEASE      compile in release mode"
@@ -144,28 +142,28 @@ add_custom_command(TARGET info
 )
 
 if(BUILD_TESTS)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} unittest                 run the project's unit tests"
         VERBATIM
     )
 endif()
 
 if(ENABLE_CLANG_FORMAT)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} format                   formats the source code"
         VERBATIM
     )
 endif()
 
 if(ENABLE_DOXYGEN)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} doxygen                  generates documentation"
         VERBATIM
     )
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL CODECOV)
-    add_custom_command(TARGET info
+    add_custom_command(TARGET BSL_INFO_TARGET
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} codecov-info            gathers info about unit test coverage"
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow  "   ${BUILD_COMMAND} codecov-upload          uploads results of unit test coverage"
         VERBATIM
@@ -176,7 +174,12 @@ endif()
 # done
 # ------------------------------------------------------------------------------
 
-add_custom_command(TARGET info
+add_custom_command(TARGET BSL_INFO_TARGET
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color " "
     VERBATIM
 )
+
+if(NOT DEFINED BSL_IS_SUBPROJECT)
+    add_custom_target(info)
+    add_dependencies(info BSL_INFO_TARGET)
+endif()


### PR DESCRIPTION
This patch ensures that the info target can be added to by
creating your own info target and using add_dependencies