### PR TITLE
Fix but in bsl interface library

### DIFF
--- a/cmake/interface/bsl.cmake
+++ b/cmake/interface/bsl.cmake
@@ -29,7 +29,3 @@ target_compile_definitions(bsl INTERFACE
     BSL_PERFORCE=${BSL_PERFORCE}
     BSL_CONSTEXPR=${BSL_CONSTEXPR}
 )
-
-target_include_directories(bsl INTERFACE
-    ${CMAKE_SOURCE_DIR}/include
-)


### PR DESCRIPTION
The interface library doesn't use the CMAKE_SOURCE_DIR from the
child, it uses it from the host, so this needs cannot be added
by bsl, and instead, needs to be added by the dependency code.