### PR TITLE
Add some missing flags, bug fix for FetchContent

### DIFF
--- a/cmake/interface/bsl.cmake
+++ b/cmake/interface/bsl.cmake
@@ -19,6 +19,8 @@
 add_library(bsl INTERFACE)
 
 target_compile_options(bsl INTERFACE
+    -ffreestanding
+    -fstack-protector-strong
     -fno-exceptions
     -fno-rtti
 )
@@ -28,4 +30,8 @@ target_compile_definitions(bsl INTERFACE
     BSL_PAGE_SIZE=${BSL_PAGE_SIZE}
     BSL_PERFORCE=${BSL_PERFORCE}
     BSL_CONSTEXPR=${BSL_CONSTEXPR}
+)
+
+target_include_directories(bsl INTERFACE
+    ${bsl_SOURCE_DIR}/include
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+include_directories(../include)
+
 add_executable(examples main.cpp)
 target_link_libraries(examples PRIVATE bsl)
 if(WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+include_directories(../include)
+
 add_subdirectory(add_const)
 add_subdirectory(add_lvalue_reference)
 add_subdirectory(add_pointer)


### PR DESCRIPTION
This patch adds some missing flags that the BSL should maintain
instead of the other projects. It also moves the includes back
to the bsl library. There is no great way to handle this issue,
and using this scheme at least keeps things encapsulated.