### PR TITLE
Fixes issues with kernel/extension compilation

### DIFF
--- a/cmake/interface/bsl.cmake
+++ b/cmake/interface/bsl.cmake
@@ -19,10 +19,9 @@
 add_library(bsl INTERFACE)
 
 target_compile_options(bsl INTERFACE
-    -ffreestanding
-    -fstack-protector-strong
     -fno-exceptions
     -fno-rtti
+    -fstack-protector-strong
 )
 
 target_compile_definitions(bsl INTERFACE

--- a/include/bsl/details/putc_stderr.hpp
+++ b/include/bsl/details/putc_stderr.hpp
@@ -29,6 +29,8 @@
 #include "../char_type.hpp"
 #include "../is_constant_evaluated.hpp"
 
+#ifndef __bareflank__
+
 #include <stdio.h>    // PRQA S 1-10000 // NOLINT
 
 namespace bsl
@@ -63,5 +65,16 @@ namespace bsl
         }
     }
 }
+
+#else
+
+namespace bsl
+{
+    template<typename T = void>
+    constexpr void
+    putc_stderr(char_type const c) noexcept;
+}
+
+#endif
 
 #endif

--- a/include/bsl/details/putc_stdout.hpp
+++ b/include/bsl/details/putc_stdout.hpp
@@ -29,6 +29,8 @@
 #include "../char_type.hpp"
 #include "../is_constant_evaluated.hpp"
 
+#ifndef __bareflank__
+
 #include <stdio.h>    // PRQA S 1-10000 // NOLINT
 
 namespace bsl
@@ -63,5 +65,16 @@ namespace bsl
         }
     }
 }
+
+#else
+
+namespace bsl
+{
+    template<typename T = void>
+    constexpr void
+    putc_stdout(char_type const c) noexcept;
+}
+
+#endif
 
 #endif

--- a/include/bsl/details/puts_stderr.hpp
+++ b/include/bsl/details/puts_stderr.hpp
@@ -29,6 +29,8 @@
 #include "../cstr_type.hpp"
 #include "../is_constant_evaluated.hpp"
 
+#ifndef __bareflank__
+
 #include <stdio.h>    // PRQA S 1-10000 // NOLINT
 
 namespace bsl
@@ -65,5 +67,16 @@ namespace bsl
         }
     }
 }
+
+#else
+
+namespace bsl
+{
+    template<typename T = void>
+    constexpr void
+    puts_stderr(cstr_type const str) noexcept;
+}
+
+#endif
 
 #endif

--- a/include/bsl/details/puts_stdout.hpp
+++ b/include/bsl/details/puts_stdout.hpp
@@ -29,6 +29,8 @@
 #include "../cstr_type.hpp"
 #include "../is_constant_evaluated.hpp"
 
+#ifndef __bareflank__
+
 #include <stdio.h>    // PRQA S 1-10000 // NOLINT
 
 namespace bsl
@@ -65,5 +67,16 @@ namespace bsl
         }
     }
 }
+
+#else
+
+namespace bsl
+{
+    template<typename T = void>
+    constexpr void
+    puts_stdout(cstr_type const str) noexcept;
+}
+
+#endif
 
 #endif

--- a/include/bsl/ifmap.hpp
+++ b/include/bsl/ifmap.hpp
@@ -34,9 +34,9 @@
 #include "safe_integral.hpp"
 #include "string_view.hpp"
 
-#if defined(_WIN32) && !BSL_PERFORCE
+#if defined(_WIN32) && !BSL_PERFORCE && !defined(__bareflank__)
 #include "details/ifmap_windows.hpp"
-#elif defined(__linux__) && !BSL_PERFORCE
+#elif defined(__linux__) && !BSL_PERFORCE && !defined(__bareflank__)
 #include "details/ifmap_linux.hpp"
 #else
 

--- a/include/bsl/ioctl.hpp
+++ b/include/bsl/ioctl.hpp
@@ -32,9 +32,9 @@
 #include "discard.hpp"
 #include "safe_integral.hpp"
 
-#if defined(_WIN32) && !BSL_PERFORCE
+#if defined(_WIN32) && !BSL_PERFORCE && !defined(__bareflank__)
 #include "details/ioctl_windows.hpp"
-#elif defined(__linux__) && !BSL_PERFORCE
+#elif defined(__linux__) && !BSL_PERFORCE && !defined(__bareflank__)
 #include "details/ioctl_linux.hpp"
 #else
 

--- a/include/bsl/ut.hpp
+++ b/include/bsl/ut.hpp
@@ -28,6 +28,8 @@
 #ifndef BSL_UT_HPP
 #define BSL_UT_HPP
 
+#ifndef __bareflank__
+
 #include "color.hpp"
 #include "convert.hpp"
 #include "cstr_type.hpp"
@@ -264,5 +266,7 @@ namespace bsl
         return test;
     }
 }
+
+#endif
 
 #endif


### PR DESCRIPTION
This patch adds a __bareflank__ macro, similar to __linux__
that Clang will define, telling us that the code is being
cross-compiled for the Bareflank kernel and extensions.
This also remove the freestanding flag from the BSL as that
will need to be set by Clang as well when this macro is
defined.