### PR TITLE
Ensure bsl::errc_type is a POD

### DIFF
--- a/examples/basic_errc_type/example_basic_errc_type_default_constructor.hpp
+++ b/examples/basic_errc_type/example_basic_errc_type_default_constructor.hpp
@@ -1,0 +1,42 @@
+/// @copyright
+/// Copyright (C) 2020 Assured Information Security, Inc.
+///
+/// @copyright
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// @copyright
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+///
+/// @copyright
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+#include <bsl/errc_type.hpp>
+#include <bsl/debug.hpp>
+
+namespace bsl
+{
+    /// <!-- description -->
+    ///   @brief Provides the example's main function
+    ///
+    inline void
+    example_basic_errc_type_default_constructor() noexcept
+    {
+        constexpr bsl::basic_errc_type<> my_errc{};
+
+        if (my_errc.success()) {
+            bsl::print() << "success\n";
+        }
+    }
+}

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -63,6 +63,7 @@
 #include "example_as_const_overview.hpp"
 #include "example_basic_errc_type_overview.hpp"
 #include "basic_errc_type/example_basic_errc_type_constructor_t.hpp"
+#include "basic_errc_type/example_basic_errc_type_default_constructor.hpp"
 #include "basic_errc_type/example_basic_errc_type_equals.hpp"
 #include "basic_errc_type/example_basic_errc_type_failure.hpp"
 #include "basic_errc_type/example_basic_errc_type_get.hpp"
@@ -512,6 +513,7 @@ main() noexcept
     example(&bsl::example_as_const_overview, "example_as_const_overview");
     example(&bsl::example_basic_errc_type_overview, "example_basic_errc_type_overview");
     example(&bsl::example_basic_errc_type_constructor_t, "example_basic_errc_type_constructor_t");
+    example(&bsl::example_basic_errc_type_default_constructor, "example_basic_errc_type_default_constructor");
     example(&bsl::example_basic_errc_type_equals, "example_basic_errc_type_equals");
     example(&bsl::example_basic_errc_type_failure, "example_basic_errc_type_failure");
     example(&bsl::example_basic_errc_type_get, "example_basic_errc_type_get");

--- a/include/bsl/basic_errc_type.hpp
+++ b/include/bsl/basic_errc_type.hpp
@@ -52,7 +52,7 @@ namespace bsl
     ///     requirements (i.e., NTSTATUS).
     ///   @include example_basic_errc_type_overview.hpp
     ///
-    template<typename T = bsl::int32, T SUCCESS = 0>
+    template<typename T = bsl::int32>
     class basic_errc_type final
     {
     public:
@@ -64,13 +64,20 @@ namespace bsl
         using const_reference_type = T const &;
 
         /// <!-- description -->
+        ///   @brief Default constructor. This ensures the type is a
+        ///     POD type, allowing it to be constructed as a global resource.
+        ///   @include basic_errc_type/example_basic_errc_type_default_constructor.hpp
+        ///
+        constexpr basic_errc_type() noexcept = default;
+
+        /// <!-- description -->
         ///   @brief Value initialization constructor
         ///   @include basic_errc_type/example_basic_errc_type_constructor_t.hpp
         ///
         /// <!-- inputs/outputs -->
         ///   @param errc the error code to store
         ///
-        explicit constexpr basic_errc_type(value_type const &errc = SUCCESS) noexcept : m_errc{errc}
+        explicit constexpr basic_errc_type(value_type const &errc) noexcept : m_errc{errc}
         {}
 
         /// <!-- description -->
@@ -102,37 +109,37 @@ namespace bsl
         }
 
         /// <!-- description -->
-        ///   @brief Returns true if the error code contains SUCCESS,
+        ///   @brief Returns true if the error code contains T{},
         ///     otherwise, if the error code contains an error code,
         ///     returns false.
         ///   @include basic_errc_type/example_basic_errc_type_success.hpp
         ///
         /// <!-- inputs/outputs -->
-        ///   @return Returns true if the error code contains SUCCESS,
+        ///   @return Returns true if the error code contains T{},
         ///     otherwise, if the error code contains an error code,
         ///     returns false.
         ///
         [[nodiscard]] constexpr bool
         success() const noexcept
         {
-            return m_errc == SUCCESS;
+            return m_errc == T{};
         }
 
         /// <!-- description -->
         ///   @brief Returns true if the error code contains an error code,
-        ///     otherwise, if the error code contains SUCCESS,
+        ///     otherwise, if the error code contains T{},
         ///     returns false.
         ///   @include basic_errc_type/example_basic_errc_type_failure.hpp
         ///
         /// <!-- inputs/outputs -->
         ///   @return Returns true if the error code contains an error code,
-        ///     otherwise, if the error code contains SUCCESS,
+        ///     otherwise, if the error code contains T{},
         ///     returns false.
         ///
         [[nodiscard]] constexpr bool
         failure() const noexcept
         {
-            return m_errc != SUCCESS;
+            return m_errc != T{};
         }
 
         /// <!-- description -->
@@ -149,7 +156,7 @@ namespace bsl
         [[nodiscard]] constexpr bool
         is_checked() const noexcept
         {
-            return m_errc < 0;
+            return m_errc < T{};
         }
 
         /// <!-- description -->
@@ -166,7 +173,7 @@ namespace bsl
         [[nodiscard]] constexpr bool
         is_unchecked() const noexcept
         {
-            return m_errc > 0;
+            return m_errc > T{};
         }
 
         /// <!-- description -->
@@ -197,10 +204,9 @@ namespace bsl
     ///   @param rhs the right hand side of the operator
     ///   @return Returns true if the lhs is equal to the rhs, false otherwise
     ///
-    template<typename T, T SUCCESS>
+    template<typename T>
     constexpr bool
-    operator==(
-        basic_errc_type<T, SUCCESS> const &lhs, basic_errc_type<T, SUCCESS> const &rhs) noexcept
+    operator==(basic_errc_type<T> const &lhs, basic_errc_type<T> const &rhs) noexcept
     {
         return lhs.get() == rhs.get();
     }
@@ -215,10 +221,9 @@ namespace bsl
     ///   @param rhs the right hand side of the operator
     ///   @return Returns false if the lhs is equal to the rhs, true otherwise
     ///
-    template<typename T, T SUCCESS>
+    template<typename T>
     constexpr bool
-    operator!=(
-        basic_errc_type<T, SUCCESS> const &lhs, basic_errc_type<T, SUCCESS> const &rhs) noexcept
+    operator!=(basic_errc_type<T> const &lhs, basic_errc_type<T> const &rhs) noexcept
     {
         return !(lhs == rhs);
     }
@@ -277,9 +282,9 @@ namespace bsl
     ///     the error code is a custom, user defined error code, returns
     ///     a nullptr.
     ///
-    template<typename T, T SUCCESS>
+    template<typename T>
     [[nodiscard]] constexpr bsl::string_view
-    basic_errc_type<T, SUCCESS>::message() const noexcept
+    basic_errc_type<T>::message() const noexcept
     {
         bsl::string_view msg{};
 
@@ -370,9 +375,9 @@ namespace bsl
     ///   @param val the basic_errc_type to output
     ///   @return return o
     ///
-    template<typename T1, typename T2, T2 SUCCESS>
+    template<typename T1, typename T2>
     [[maybe_unused]] constexpr out<T1>
-    operator<<(out<T1> const o, basic_errc_type<T2, SUCCESS> const &val) noexcept
+    operator<<(out<T1> const o, basic_errc_type<T2> const &val) noexcept
     {
         if constexpr (!o) {
             return o;

--- a/tests/basic_errc_type/behavior.cpp
+++ b/tests/basic_errc_type/behavior.cpp
@@ -39,6 +39,13 @@ tests() noexcept
 {
     bsl::ut_scenario{"constructor / get"} = []() {
         bsl::ut_given{} = []() {
+            bsl::basic_errc_type<> errc{};
+            bsl::ut_then{} = [&errc]() {
+                bsl::ut_check(errc.get() == 0);
+            };
+        };
+
+        bsl::ut_given{} = []() {
             bsl::basic_errc_type<> errc{42};
             bsl::ut_then{} = [&errc]() {
                 bsl::ut_check(errc.get() == 42);

--- a/tests/basic_errc_type/requirements.cpp
+++ b/tests/basic_errc_type/requirements.cpp
@@ -24,10 +24,13 @@
 
 #include <bsl/basic_errc_type.hpp>
 #include <bsl/discard.hpp>
+#include <bsl/is_pod.hpp>
 #include <bsl/ut.hpp>
 
 namespace
 {
+    bsl::basic_errc_type<> pod;
+
     class fixture_t final
     {
         bsl::basic_errc_type<> errc{};
@@ -77,6 +80,11 @@ bsl::exit_code
 main() noexcept
 {
     using namespace bsl;
+
+    bsl::ut_scenario{"verify supports global POD"} = []() {
+        bsl::discard(pod);
+        static_assert(is_pod<decltype(pod)>::value);
+    };
 
     bsl::ut_scenario{"verify noexcept"} = []() {
         bsl::ut_given{} = []() {


### PR DESCRIPTION
This patch makes sure that a bsl::errc_type is a POD so that
it can be used in a syscall by the hypervisor.