### PR TITLE
Clang Tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -61,20 +61,9 @@
 #
 #  Perforce currently does not support this. Once it does, we can remove this
 #
-# -hicpp-avoid-c-arrays
-# -modernize-avoid-c-arrays
-# -cppcoreguidelines-avoid-c-arrays
-# -hicpp-no-array-decay
-# -cppcoreguidelines-pro-bounds-array-to-pointer-decay
-# -cppcoreguidelines-pro-bounds-constant-array-index
-# -cppcoreguidelines-owning-memory
-#
-#  These should all be enabled, but they cannot be in this library as we
-#  implement the APIs that these checks depend on.
-#
 
-Checks: 'clang-diagnostic-*,clang-analyzer-*,-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-modernize-use-default-member-init,-readability-redundant-member-init,-cert-dcl21-cpp,-cert-oop54-cpp,-readability-avoid-const-params-in-decls,-readability-static-accessed-through-instance,-modernize-concat-nested-namespaces,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-hicpp-no-array-decay,-hicpp-avoid-c-arrays,-modernize-avoid-c-arrays,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-owning-memory'
-WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-modernize-use-default-member-init,-readability-redundant-member-init,-cert-dcl21-cpp,-cert-oop54-cpp,-readability-avoid-const-params-in-decls,-readability-static-accessed-through-instance,-modernize-concat-nested-namespaces,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-hicpp-no-array-decay,-hicpp-avoid-c-arrays,-modernize-avoid-c-arrays,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-owning-memory'
+Checks: 'clang-diagnostic-*,clang-analyzer-*,-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-modernize-use-default-member-init,-readability-redundant-member-init,-cert-dcl21-cpp,-cert-oop54-cpp,-readability-avoid-const-params-in-decls,-readability-static-accessed-through-instance,-modernize-concat-nested-namespaces'
+WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-modernize-use-default-member-init,-readability-redundant-member-init,-cert-dcl21-cpp,-cert-oop54-cpp,-readability-avoid-const-params-in-decls,-readability-static-accessed-through-instance,-modernize-concat-nested-namespaces'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 CheckOptions:

--- a/include/bsl/details/fmt_impl_integral.hpp
+++ b/include/bsl/details/fmt_impl_integral.hpp
@@ -166,7 +166,7 @@ namespace bsl
             }
 
             for (safe_uintmax i{info.num}; i.is_pos(); --i) {
-                o.write(info.buf[(i - safe_uintmax::one()).get()]);
+                o.write(info.buf[(i - safe_uintmax::one()).get()]);    // NOLINT
             }
         }
 
@@ -206,7 +206,7 @@ namespace bsl
             }
 
             for (safe_uintmax i{info.num}; i.is_pos(); --i) {
-                o.write(info.buf[(i - safe_uintmax::one()).get()]);
+                o.write(info.buf[(i - safe_uintmax::one()).get()]);    // NOLINT
             }
         }
 

--- a/include/bsl/details/fmt_impl_integral_helpers.hpp
+++ b/include/bsl/details/fmt_impl_integral_helpers.hpp
@@ -57,7 +57,7 @@ namespace bsl
             /// @brief stores the total number digits that make up the integral
             safe_uintmax num;
             /// @brief stores the integral as a string in reverse
-            char_type buf[max_num_digits.get()];
+            char_type buf[max_num_digits.get()];    // NOLINT
         };
 
         /// <!-- description -->
@@ -161,7 +161,7 @@ namespace bsl
                         digit += convert<T>('0');
                     }
 
-                    info.buf[info.num.get()] = static_cast<char_type>(digit.get());
+                    info.buf[info.num.get()] = static_cast<char_type>(digit.get());    // NOLINT
                 }
             }
 
@@ -241,7 +241,7 @@ namespace bsl
             }
             else {
                 for (safe_uintmax i{info.num}; i.is_pos(); --i) {
-                    o.write(info.buf[(i - safe_uintmax::one()).get()]);
+                    o.write(info.buf[(i - safe_uintmax::one()).get()]);    // NOLINT
                 }
             }
 

--- a/tests/basic_string_view/behavior_string_view.cpp
+++ b/tests/basic_string_view/behavior_string_view.cpp
@@ -44,7 +44,7 @@ namespace
     template<bsl::uintmax N>
     struct test_string_view final
     {
-        bsl::char_type data[N]{};
+        bsl::char_type data[N]{};    // NOLINT
         bsl::safe_uintmax size{};
     };
 
@@ -60,7 +60,7 @@ namespace
         }
 
         for (bsl::safe_uintmax i{}; i < lhs.size; ++i) {
-            if (lhs.data[i.get()] != str[i.get()]) {
+            if (lhs.data[i.get()] != str[i.get()]) {    // NOLINT
                 return false;
             }
         }
@@ -86,7 +86,7 @@ namespace bsl
         void
         putc_stdout(bsl::char_type const c) noexcept
         {
-            res.data[res.size.get()] = c;
+            res.data[res.size.get()] = c;    // NOLINT
             ++res.size;
         }
 
@@ -94,7 +94,7 @@ namespace bsl
         puts_stdout(bsl::cstr_type const str) noexcept
         {
             for (bsl::safe_uintmax i{}; i < bsl::builtin_strlen(str); ++i) {
-                res.data[res.size.get()] = str[i.get()];
+                res.data[res.size.get()] = str[i.get()];    // NOLINT
                 ++res.size;
             }
         }

--- a/tests/fmt/behavior_bool.cpp
+++ b/tests/fmt/behavior_bool.cpp
@@ -44,7 +44,7 @@ namespace
     template<bsl::uintmax N>
     struct test_string_view final
     {
-        bsl::char_type data[N]{};
+        bsl::char_type data[N]{};    // NOLINT
         bsl::safe_uintmax size{};
     };
 
@@ -60,7 +60,7 @@ namespace
         }
 
         for (bsl::safe_uintmax i{}; i < lhs.size; ++i) {
-            if (lhs.data[i.get()] != str[i.get()]) {
+            if (lhs.data[i.get()] != str[i.get()]) {    // NOLINT
                 return false;
             }
         }
@@ -86,7 +86,7 @@ namespace bsl
         void
         putc_stdout(bsl::char_type const c) noexcept
         {
-            res.data[res.size.get()] = c;
+            res.data[res.size.get()] = c;    // NOLINT
             ++res.size;
         }
 
@@ -94,7 +94,7 @@ namespace bsl
         puts_stdout(bsl::cstr_type const str) noexcept
         {
             for (bsl::safe_uintmax i{}; i < bsl::builtin_strlen(str); ++i) {
-                res.data[res.size.get()] = str[i.get()];
+                res.data[res.size.get()] = str[i.get()];    // NOLINT
                 ++res.size;
             }
         }

--- a/tests/fmt/behavior_char_type.cpp
+++ b/tests/fmt/behavior_char_type.cpp
@@ -44,7 +44,7 @@ namespace
     template<bsl::uintmax N>
     struct test_string_view final
     {
-        bsl::char_type data[N]{};
+        bsl::char_type data[N]{};    // NOLINT
         bsl::safe_uintmax size{};
     };
 
@@ -60,7 +60,7 @@ namespace
         }
 
         for (bsl::safe_uintmax i{}; i < lhs.size; ++i) {
-            if (lhs.data[i.get()] != str[i.get()]) {
+            if (lhs.data[i.get()] != str[i.get()]) {    // NOLINT
                 return false;
             }
         }
@@ -86,7 +86,7 @@ namespace bsl
         void
         putc_stdout(bsl::char_type const c) noexcept
         {
-            res.data[res.size.get()] = c;
+            res.data[res.size.get()] = c;    // NOLINT
             ++res.size;
         }
 
@@ -94,7 +94,7 @@ namespace bsl
         puts_stdout(bsl::cstr_type const str) noexcept
         {
             for (bsl::safe_uintmax i{}; i < bsl::builtin_strlen(str); ++i) {
-                res.data[res.size.get()] = str[i.get()];
+                res.data[res.size.get()] = str[i.get()];    // NOLINT
                 ++res.size;
             }
         }

--- a/tests/fmt/behavior_cstr_type.cpp
+++ b/tests/fmt/behavior_cstr_type.cpp
@@ -44,7 +44,7 @@ namespace
     template<bsl::uintmax N>
     struct test_string_view final
     {
-        bsl::char_type data[N]{};
+        bsl::char_type data[N]{};    // NOLINT
         bsl::safe_uintmax size{};
     };
 
@@ -60,7 +60,7 @@ namespace
         }
 
         for (bsl::safe_uintmax i{}; i < lhs.size; ++i) {
-            if (lhs.data[i.get()] != str[i.get()]) {
+            if (lhs.data[i.get()] != str[i.get()]) {    // NOLINT
                 return false;
             }
         }
@@ -86,7 +86,7 @@ namespace bsl
         void
         putc_stdout(bsl::char_type const c) noexcept
         {
-            res.data[res.size.get()] = c;
+            res.data[res.size.get()] = c;    // NOLINT
             ++res.size;
         }
 
@@ -94,7 +94,7 @@ namespace bsl
         puts_stdout(bsl::cstr_type const str) noexcept
         {
             for (bsl::safe_uintmax i{}; i < bsl::builtin_strlen(str); ++i) {
-                res.data[res.size.get()] = str[i.get()];
+                res.data[res.size.get()] = str[i.get()];    // NOLINT
                 ++res.size;
             }
         }

--- a/tests/fmt/behavior_integral.cpp
+++ b/tests/fmt/behavior_integral.cpp
@@ -44,7 +44,7 @@ namespace
     template<bsl::uintmax N>
     struct test_string_view final
     {
-        bsl::char_type data[N]{};
+        bsl::char_type data[N]{};    // NOLINT
         bsl::safe_uintmax size{};
     };
 
@@ -60,7 +60,7 @@ namespace
         }
 
         for (bsl::safe_uintmax i{}; i < lhs.size; ++i) {
-            if (lhs.data[i.get()] != str[i.get()]) {
+            if (lhs.data[i.get()] != str[i.get()]) {    // NOLINT
                 return false;
             }
         }
@@ -86,7 +86,7 @@ namespace bsl
         void
         putc_stdout(bsl::char_type const c) noexcept
         {
-            res.data[res.size.get()] = c;
+            res.data[res.size.get()] = c;    // NOLINT
             ++res.size;
         }
 
@@ -94,7 +94,7 @@ namespace bsl
         puts_stdout(bsl::cstr_type const str) noexcept
         {
             for (bsl::safe_uintmax i{}; i < bsl::builtin_strlen(str); ++i) {
-                res.data[res.size.get()] = str[i.get()];
+                res.data[res.size.get()] = str[i.get()];    // NOLINT
                 ++res.size;
             }
         }

--- a/tests/fmt/behavior_null_pointer.cpp
+++ b/tests/fmt/behavior_null_pointer.cpp
@@ -44,7 +44,7 @@ namespace
     template<bsl::uintmax N>
     struct test_string_view final
     {
-        bsl::char_type data[N]{};
+        bsl::char_type data[N]{};    // NOLINT
         bsl::safe_uintmax size{};
     };
 
@@ -60,7 +60,7 @@ namespace
         }
 
         for (bsl::safe_uintmax i{}; i < lhs.size; ++i) {
-            if (lhs.data[i.get()] != str[i.get()]) {
+            if (lhs.data[i.get()] != str[i.get()]) {    // NOLINT
                 return false;
             }
         }
@@ -86,7 +86,7 @@ namespace bsl
         void
         putc_stdout(bsl::char_type const c) noexcept
         {
-            res.data[res.size.get()] = c;
+            res.data[res.size.get()] = c;    // NOLINT
             ++res.size;
         }
 
@@ -94,7 +94,7 @@ namespace bsl
         puts_stdout(bsl::cstr_type const str) noexcept
         {
             for (bsl::safe_uintmax i{}; i < bsl::builtin_strlen(str); ++i) {
-                res.data[res.size.get()] = str[i.get()];
+                res.data[res.size.get()] = str[i.get()];    // NOLINT
                 ++res.size;
             }
         }

--- a/tests/fmt/behavior_void_pointer.cpp
+++ b/tests/fmt/behavior_void_pointer.cpp
@@ -44,7 +44,7 @@ namespace
     template<bsl::uintmax N>
     struct test_string_view final
     {
-        bsl::char_type data[N]{};
+        bsl::char_type data[N]{};    // NOLINT
         bsl::safe_uintmax size{};
     };
 
@@ -60,7 +60,7 @@ namespace
         }
 
         for (bsl::safe_uintmax i{}; i < lhs.size; ++i) {
-            if (lhs.data[i.get()] != str[i.get()]) {
+            if (lhs.data[i.get()] != str[i.get()]) {    // NOLINT
                 return false;
             }
         }
@@ -86,7 +86,7 @@ namespace bsl
         void
         putc_stdout(bsl::char_type const c) noexcept
         {
-            res.data[res.size.get()] = c;
+            res.data[res.size.get()] = c;    // NOLINT
             ++res.size;
         }
 
@@ -94,7 +94,7 @@ namespace bsl
         puts_stdout(bsl::cstr_type const str) noexcept
         {
             for (bsl::safe_uintmax i{}; i < bsl::builtin_strlen(str); ++i) {
-                res.data[res.size.get()] = str[i.get()];
+                res.data[res.size.get()] = str[i.get()];    // NOLINT
                 ++res.size;
             }
         }


### PR DESCRIPTION
This patch fixes the BSL so that it has the same Clang Tidy file
as the rest of the projects.