### PR TITLE
Add C files to the format target

### DIFF
--- a/cmake/target/format.cmake
+++ b/cmake/target/format.cmake
@@ -27,18 +27,35 @@ if(ENABLE_CLANG_FORMAT)
     file(GLOB SUBDIRS RELATIVE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/*)
     foreach(DIR ${SUBDIRS})
         if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/${DIR} AND NOT DIR MATCHES "^[\.].*" AND NOT DIR MATCHES "^build")
-            file(GLOB_RECURSE HEADERS RELATIVE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/${DIR}/*.hpp)
-            file(GLOB_RECURSE SOURCES RELATIVE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/${DIR}/*.cpp)
-            if(NOT "${HEADERS}" STREQUAL "")
+            file(GLOB_RECURSE FILES RELATIVE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/${DIR}/*.h)
+            if(NOT "${FILES}" STREQUAL "")
                 add_custom_command(TARGET format
-                    COMMAND ${CMAKE_COMMAND} -E echo " - formatting headers in: ${DIR}"
-                    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} ${BF_CLANG_FORMAT} -i ${HEADERS}
+                    COMMAND ${CMAKE_COMMAND} -E echo " - formatting c headers in: ${DIR}"
+                    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} ${BF_CLANG_FORMAT} -i ${FILES}
                 )
             endif()
-            if(NOT "${SOURCES}" STREQUAL "")
+
+            file(GLOB_RECURSE FILES RELATIVE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/${DIR}/*.hpp)
+            if(NOT "${FILES}" STREQUAL "")
                 add_custom_command(TARGET format
-                    COMMAND ${CMAKE_COMMAND} -E echo " - formatting sources in: ${DIR}"
-                    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} ${BF_CLANG_FORMAT} -i ${SOURCES}
+                    COMMAND ${CMAKE_COMMAND} -E echo " - formatting c++ headers in: ${DIR}"
+                    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} ${BF_CLANG_FORMAT} -i ${FILES}
+                )
+            endif()
+
+            file(GLOB_RECURSE FILES RELATIVE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/${DIR}/*.c)
+            if(NOT "${FILES}" STREQUAL "")
+                add_custom_command(TARGET format
+                    COMMAND ${CMAKE_COMMAND} -E echo " - formatting c sources in: ${DIR}"
+                    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} ${BF_CLANG_FORMAT} -i ${FILES}
+                )
+            endif()
+
+            file(GLOB_RECURSE FILES RELATIVE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/${DIR}/*.cpp)
+            if(NOT "${FILES}" STREQUAL "")
+                add_custom_command(TARGET format
+                    COMMAND ${CMAKE_COMMAND} -E echo " - formatting c++ sources in: ${DIR}"
+                    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} ${BF_CLANG_FORMAT} -i ${FILES}
                 )
             endif()
         endif()


### PR DESCRIPTION
This patch adds C header and source support to the format
target so that our driver logic is being formatted as well.