### PR TITLE
Switch from __bareflank__ to BAREFLANK

### DIFF
--- a/include/bsl/details/putc_stderr.hpp
+++ b/include/bsl/details/putc_stderr.hpp
@@ -42,7 +42,7 @@ namespace bsl
     }
 }
 
-#ifndef __bareflank__
+#ifndef BAREFLANK
 
 #include <stdio.h>    // PRQA S 1-10000 // NOLINT
 

--- a/include/bsl/details/putc_stdout.hpp
+++ b/include/bsl/details/putc_stdout.hpp
@@ -42,7 +42,7 @@ namespace bsl
     }
 }
 
-#ifndef __bareflank__
+#ifndef BAREFLANK
 
 #include <stdio.h>    // PRQA S 1-10000 // NOLINT
 

--- a/include/bsl/details/puts_stderr.hpp
+++ b/include/bsl/details/puts_stderr.hpp
@@ -42,7 +42,7 @@ namespace bsl
     }
 }
 
-#ifndef __bareflank__
+#ifndef BAREFLANK
 
 #include <stdio.h>    // PRQA S 1-10000 // NOLINT
 

--- a/include/bsl/details/puts_stdout.hpp
+++ b/include/bsl/details/puts_stdout.hpp
@@ -42,7 +42,7 @@ namespace bsl
     }
 }
 
-#ifndef __bareflank__
+#ifndef BAREFLANK
 
 #include <stdio.h>    // PRQA S 1-10000 // NOLINT
 

--- a/include/bsl/ifmap.hpp
+++ b/include/bsl/ifmap.hpp
@@ -34,9 +34,9 @@
 #include "safe_integral.hpp"
 #include "string_view.hpp"
 
-#if defined(_WIN32) && !BSL_PERFORCE && !defined(__bareflank__)
+#if defined(_WIN32) && !BSL_PERFORCE && !defined(BAREFLANK)
 #include "details/ifmap_windows.hpp"
-#elif defined(__linux__) && !BSL_PERFORCE && !defined(__bareflank__)
+#elif defined(__linux__) && !BSL_PERFORCE && !defined(BAREFLANK)
 #include "details/ifmap_linux.hpp"
 #else
 

--- a/include/bsl/ioctl.hpp
+++ b/include/bsl/ioctl.hpp
@@ -32,9 +32,9 @@
 #include "discard.hpp"
 #include "safe_integral.hpp"
 
-#if defined(_WIN32) && !BSL_PERFORCE && !defined(__bareflank__)
+#if defined(_WIN32) && !BSL_PERFORCE && !defined(BAREFLANK)
 #include "details/ioctl_windows.hpp"
-#elif defined(__linux__) && !BSL_PERFORCE && !defined(__bareflank__)
+#elif defined(__linux__) && !BSL_PERFORCE && !defined(BAREFLANK)
 #include "details/ioctl_linux.hpp"
 #else
 


### PR DESCRIPTION
Now that we are using ExternalProject_Add, there is no need to
modify Clang. Since, Clang is not being modified, we need to
use a C standard name for when our kernel is being compiled