### PR TITLE
Add a default constructor to the ifmap

### DIFF
--- a/examples/ifmap/example_ifmap_default_constructor.hpp
+++ b/examples/ifmap/example_ifmap_default_constructor.hpp
@@ -1,0 +1,41 @@
+/// @copyright
+/// Copyright (C) 2020 Assured Information Security, Inc.
+///
+/// @copyright
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// @copyright
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+///
+/// @copyright
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+#include <bsl/ifmap.hpp>
+#include <bsl/debug.hpp>
+
+namespace bsl
+{
+    /// <!-- description -->
+    ///   @brief Provides the example's main function
+    ///
+    inline void
+    example_ifmap_default_constructor() noexcept
+    {
+        bsl::ifmap const map{};
+        if (!map) {
+            bsl::print() << "success\n";
+        }
+    }
+}

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -202,6 +202,7 @@
 // #include "example_ifmap_overview.hpp"
 // #include "ifmap/example_ifmap_constructor.hpp"
 // #include "ifmap/example_ifmap_data.hpp"
+// #include "ifmap/example_ifmap_default_constructor.hpp"
 // #include "ifmap/example_ifmap_empty.hpp"
 // #include "ifmap/example_ifmap_max_size.hpp"
 // #include "ifmap/example_ifmap_operator_bool.hpp"
@@ -652,6 +653,7 @@ main() noexcept
     // example(&bsl::example_ifmap_overview, "example_ifmap_overview");
     // example(&bsl::example_ifmap_constructor, "example_ifmap_constructor");
     // example(&bsl::example_ifmap_data, "example_ifmap_data");
+    // example(&bsl::example_ifmap_default_constructor, "example_ifmap_default_constructor");
     // example(&bsl::example_ifmap_empty, "example_ifmap_empty");
     // example(&bsl::example_ifmap_max_size, "example_ifmap_max_size");
     // example(&bsl::example_ifmap_operator_bool, "example_ifmap_operator_bool");

--- a/include/bsl/details/ifmap_linux.hpp
+++ b/include/bsl/details/ifmap_linux.hpp
@@ -69,6 +69,12 @@ namespace bsl
         using const_pointer_type = void const *;
 
         /// <!-- description -->
+        ///   @brief Creates a default ifmap that has not yet been mapped.
+        ///   @include ifmap/example_ifmap_default_constructor.hpp
+        ///
+        ifmap() noexcept = default;
+
+        /// <!-- description -->
         ///   @brief Creates a bsl::ifmap given a the filename and path of
         ///     the file to map as read-only.
         ///   @include ifmap/example_ifmap_constructor.hpp

--- a/include/bsl/details/ifmap_windows.hpp
+++ b/include/bsl/details/ifmap_windows.hpp
@@ -69,6 +69,12 @@ namespace bsl
         using const_pointer_type = void const *;
 
         /// <!-- description -->
+        ///   @brief Creates a default ifmap that has not yet been mapped.
+        ///   @include ifmap/example_ifmap_default_constructor.hpp
+        ///
+        ifmap() noexcept = default;
+
+        /// <!-- description -->
         ///   @brief Creates a bsl::ifmap given a the filename and path of
         ///     the file to map as read-only.
         ///   @include ifmap/example_ifmap_constructor.hpp

--- a/include/bsl/ifmap.hpp
+++ b/include/bsl/ifmap.hpp
@@ -64,6 +64,12 @@ namespace bsl
         using const_pointer_type = void const *;
 
         /// <!-- description -->
+        ///   @brief Creates a default ifmap that has not yet been mapped.
+        ///   @include ifmap/example_ifmap_default_constructor.hpp
+        ///
+        ifmap() noexcept = default;
+
+        /// <!-- description -->
         ///   @brief Creates a bsl::ifmap given a the filename and path of
         ///     the file to map as read-only.
         ///   @include ifmap/example_ifmap_constructor.hpp

--- a/tests/basic_string_view/behavior_string_view.cpp
+++ b/tests/basic_string_view/behavior_string_view.cpp
@@ -23,7 +23,7 @@
 /// SOFTWARE.
 
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
-#define __bareflank__
+#define BAREFLANK
 
 #include <stdio.h>    // NOLINT
 

--- a/tests/fmt/behavior_bool.cpp
+++ b/tests/fmt/behavior_bool.cpp
@@ -23,7 +23,7 @@
 /// SOFTWARE.
 
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
-#define __bareflank__
+#define BAREFLANK
 
 #include <stdio.h>    // NOLINT
 

--- a/tests/fmt/behavior_char_type.cpp
+++ b/tests/fmt/behavior_char_type.cpp
@@ -23,7 +23,7 @@
 /// SOFTWARE.
 
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
-#define __bareflank__
+#define BAREFLANK
 
 #include <stdio.h>    // NOLINT
 

--- a/tests/fmt/behavior_cstr_type.cpp
+++ b/tests/fmt/behavior_cstr_type.cpp
@@ -23,7 +23,7 @@
 /// SOFTWARE.
 
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
-#define __bareflank__
+#define BAREFLANK
 
 #include <stdio.h>    // NOLINT
 

--- a/tests/fmt/behavior_integral.cpp
+++ b/tests/fmt/behavior_integral.cpp
@@ -23,7 +23,7 @@
 /// SOFTWARE.
 
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
-#define __bareflank__
+#define BAREFLANK
 
 #include <stdio.h>    // NOLINT
 

--- a/tests/fmt/behavior_null_pointer.cpp
+++ b/tests/fmt/behavior_null_pointer.cpp
@@ -23,7 +23,7 @@
 /// SOFTWARE.
 
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
-#define __bareflank__
+#define BAREFLANK
 
 #include <stdio.h>    // NOLINT
 

--- a/tests/fmt/behavior_void_pointer.cpp
+++ b/tests/fmt/behavior_void_pointer.cpp
@@ -23,7 +23,7 @@
 /// SOFTWARE.
 
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
-#define __bareflank__
+#define BAREFLANK
 
 #include <stdio.h>    // NOLINT
 

--- a/tests/ifmap/behavior.cpp
+++ b/tests/ifmap/behavior.cpp
@@ -38,6 +38,13 @@ main() noexcept
 {
     bsl::ut_scenario{"constructor"} = []() {
         bsl::ut_given{} = []() {
+            bsl::ifmap map{};
+            bsl::ut_then{} = [&map]() {
+                bsl::ut_check(!map);
+            };
+        };
+
+        bsl::ut_given{} = []() {
             bsl::ifmap map{"blah"};
             bsl::ut_then{} = [&map]() {
                 bsl::ut_check(!map);


### PR DESCRIPTION
This patch adds a default constructor to the ifmap. It also
addresses a regression with _bareflank_