### PR TITLE
Add the ability to increment a bsl::arguments

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -61,9 +61,15 @@
 #
 #  Perforce currently does not support this. Once it does, we can remove this
 #
+# -misc-misplaced-const
+#
+#  Not really sure why this check was added as it is perfectly ok to have a
+#  pointer marked as, for example, int * const ptr, stating that the pointer
+#  is read-only, but the memory being pointed to is read/write.
+#
 
-Checks: 'clang-diagnostic-*,clang-analyzer-*,-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-modernize-use-default-member-init,-readability-redundant-member-init,-cert-dcl21-cpp,-cert-oop54-cpp,-readability-avoid-const-params-in-decls,-readability-static-accessed-through-instance,-modernize-concat-nested-namespaces'
-WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-modernize-use-default-member-init,-readability-redundant-member-init,-cert-dcl21-cpp,-cert-oop54-cpp,-readability-avoid-const-params-in-decls,-readability-static-accessed-through-instance,-modernize-concat-nested-namespaces'
+Checks: 'clang-diagnostic-*,clang-analyzer-*,-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-modernize-use-default-member-init,-readability-redundant-member-init,-cert-dcl21-cpp,-cert-oop54-cpp,-readability-avoid-const-params-in-decls,-readability-static-accessed-through-instance,-modernize-concat-nested-namespaces,-misc-misplaced-const'
+WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,readability-*,-modernize-use-trailing-return-type,-modernize-use-default-member-init,-readability-redundant-member-init,-cert-dcl21-cpp,-cert-oop54-cpp,-readability-avoid-const-params-in-decls,-readability-static-accessed-through-instance,-modernize-concat-nested-namespaces,-misc-misplaced-const'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 CheckOptions:

--- a/examples/arguments/example_arguments_at.hpp
+++ b/examples/arguments/example_arguments_at.hpp
@@ -22,45 +22,23 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#include <bsl/spinlock.hpp>
-#include <bsl/is_pod.hpp>
-#include <bsl/ut.hpp>
+#include <bsl/arguments.hpp>
+#include <bsl/array.hpp>
+#include <bsl/debug.hpp>
 
-namespace
+namespace bsl
 {
-    bsl::spinlock const pod{};
-}
+    /// <!-- description -->
+    ///   @brief Provides the example's main function
+    ///
+    inline void
+    example_arguments_at() noexcept
+    {
+        constexpr bsl::array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+        bsl::arguments const args{argv.size(), argv.data()};
 
-/// <!-- description -->
-///   @brief Main function for this unit test. If a call to ut_check() fails
-///     the application will fast fail. If all calls to ut_check() pass, this
-///     function will successfully return with bsl::exit_success.
-///
-/// <!-- inputs/outputs -->
-///   @return Always returns bsl::exit_success.
-///
-bsl::exit_code
-main() noexcept
-{
-    using namespace bsl;
-
-    bsl::ut_scenario{"verify supports global POD"} = []() {
-        bsl::discard(pod);
-        static_assert(is_pod<decltype(pod)>::value);
-    };
-
-    bsl::ut_scenario{"verify noexcept"} = []() {
-        bsl::ut_given{} = []() {
-            spinlock lck{};
-            bsl::ut_then{} = []() {
-                static_assert(noexcept(spinlock{}));
-                static_assert(noexcept(spinlock{true}));
-                static_assert(noexcept(lck.lock()));
-                static_assert(noexcept(lck.try_lock()));
-                static_assert(noexcept(lck.unlock()));
-            };
-        };
-    };
-
-    return bsl::ut_success();
+        if (args.at<bsl::string_view>(bsl::to_umax(3)) == "16") {
+            bsl::print() << "success\n";
+        }
+    }
 }

--- a/examples/arguments/example_arguments_back.hpp
+++ b/examples/arguments/example_arguments_back.hpp
@@ -22,45 +22,23 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#include <bsl/spinlock.hpp>
-#include <bsl/is_pod.hpp>
-#include <bsl/ut.hpp>
+#include <bsl/arguments.hpp>
+#include <bsl/array.hpp>
+#include <bsl/debug.hpp>
 
-namespace
+namespace bsl
 {
-    bsl::spinlock const pod{};
-}
+    /// <!-- description -->
+    ///   @brief Provides the example's main function
+    ///
+    inline void
+    example_arguments_back() noexcept
+    {
+        constexpr bsl::array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+        bsl::arguments args{argv.size(), argv.data()};
 
-/// <!-- description -->
-///   @brief Main function for this unit test. If a call to ut_check() fails
-///     the application will fast fail. If all calls to ut_check() pass, this
-///     function will successfully return with bsl::exit_success.
-///
-/// <!-- inputs/outputs -->
-///   @return Always returns bsl::exit_success.
-///
-bsl::exit_code
-main() noexcept
-{
-    using namespace bsl;
-
-    bsl::ut_scenario{"verify supports global POD"} = []() {
-        bsl::discard(pod);
-        static_assert(is_pod<decltype(pod)>::value);
-    };
-
-    bsl::ut_scenario{"verify noexcept"} = []() {
-        bsl::ut_given{} = []() {
-            spinlock lck{};
-            bsl::ut_then{} = []() {
-                static_assert(noexcept(spinlock{}));
-                static_assert(noexcept(spinlock{true}));
-                static_assert(noexcept(lck.lock()));
-                static_assert(noexcept(lck.try_lock()));
-                static_assert(noexcept(lck.unlock()));
-            };
-        };
-    };
-
-    return bsl::ut_success();
+        if (args.back<bsl::string_view>() == "42") {
+            bsl::print() << "success\n";
+        }
+    }
 }

--- a/examples/arguments/example_arguments_empty.hpp
+++ b/examples/arguments/example_arguments_empty.hpp
@@ -22,45 +22,23 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#include <bsl/spinlock.hpp>
-#include <bsl/is_pod.hpp>
-#include <bsl/ut.hpp>
+#include <bsl/arguments.hpp>
+#include <bsl/array.hpp>
+#include <bsl/debug.hpp>
 
-namespace
+namespace bsl
 {
-    bsl::spinlock const pod{};
-}
+    /// <!-- description -->
+    ///   @brief Provides the example's main function
+    ///
+    inline void
+    example_arguments_empty() noexcept
+    {
+        constexpr bsl::array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+        bsl::arguments const args{argv.size(), argv.data()};
 
-/// <!-- description -->
-///   @brief Main function for this unit test. If a call to ut_check() fails
-///     the application will fast fail. If all calls to ut_check() pass, this
-///     function will successfully return with bsl::exit_success.
-///
-/// <!-- inputs/outputs -->
-///   @return Always returns bsl::exit_success.
-///
-bsl::exit_code
-main() noexcept
-{
-    using namespace bsl;
-
-    bsl::ut_scenario{"verify supports global POD"} = []() {
-        bsl::discard(pod);
-        static_assert(is_pod<decltype(pod)>::value);
-    };
-
-    bsl::ut_scenario{"verify noexcept"} = []() {
-        bsl::ut_given{} = []() {
-            spinlock lck{};
-            bsl::ut_then{} = []() {
-                static_assert(noexcept(spinlock{}));
-                static_assert(noexcept(spinlock{true}));
-                static_assert(noexcept(lck.lock()));
-                static_assert(noexcept(lck.try_lock()));
-                static_assert(noexcept(lck.unlock()));
-            };
-        };
-    };
-
-    return bsl::ut_success();
+        if (!args.empty()) {
+            bsl::print() << "success\n";
+        }
+    }
 }

--- a/examples/arguments/example_arguments_front.hpp
+++ b/examples/arguments/example_arguments_front.hpp
@@ -22,45 +22,23 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#include <bsl/spinlock.hpp>
-#include <bsl/is_pod.hpp>
-#include <bsl/ut.hpp>
+#include <bsl/arguments.hpp>
+#include <bsl/array.hpp>
+#include <bsl/debug.hpp>
 
-namespace
+namespace bsl
 {
-    bsl::spinlock const pod{};
-}
+    /// <!-- description -->
+    ///   @brief Provides the example's main function
+    ///
+    inline void
+    example_arguments_front() noexcept
+    {
+        constexpr bsl::array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+        bsl::arguments const args{argv.size(), argv.data()};
 
-/// <!-- description -->
-///   @brief Main function for this unit test. If a call to ut_check() fails
-///     the application will fast fail. If all calls to ut_check() pass, this
-///     function will successfully return with bsl::exit_success.
-///
-/// <!-- inputs/outputs -->
-///   @return Always returns bsl::exit_success.
-///
-bsl::exit_code
-main() noexcept
-{
-    using namespace bsl;
-
-    bsl::ut_scenario{"verify supports global POD"} = []() {
-        bsl::discard(pod);
-        static_assert(is_pod<decltype(pod)>::value);
-    };
-
-    bsl::ut_scenario{"verify noexcept"} = []() {
-        bsl::ut_given{} = []() {
-            spinlock lck{};
-            bsl::ut_then{} = []() {
-                static_assert(noexcept(spinlock{}));
-                static_assert(noexcept(spinlock{true}));
-                static_assert(noexcept(lck.lock()));
-                static_assert(noexcept(lck.try_lock()));
-                static_assert(noexcept(lck.unlock()));
-            };
-        };
-    };
-
-    return bsl::ut_success();
+        if (args.front<bsl::string_view>() == "4") {
+            bsl::print() << "success\n";
+        }
+    }
 }

--- a/examples/arguments/example_arguments_increment.hpp
+++ b/examples/arguments/example_arguments_increment.hpp
@@ -22,45 +22,24 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#include <bsl/spinlock.hpp>
-#include <bsl/is_pod.hpp>
-#include <bsl/ut.hpp>
+#include <bsl/arguments.hpp>
+#include <bsl/array.hpp>
+#include <bsl/debug.hpp>
 
-namespace
+namespace bsl
 {
-    bsl::spinlock const pod{};
-}
+    /// <!-- description -->
+    ///   @brief Provides the example's main function
+    ///
+    inline void
+    example_arguments_increment() noexcept
+    {
+        constexpr bsl::array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+        bsl::arguments args{argv.size(), argv.data()};
 
-/// <!-- description -->
-///   @brief Main function for this unit test. If a call to ut_check() fails
-///     the application will fast fail. If all calls to ut_check() pass, this
-///     function will successfully return with bsl::exit_success.
-///
-/// <!-- inputs/outputs -->
-///   @return Always returns bsl::exit_success.
-///
-bsl::exit_code
-main() noexcept
-{
-    using namespace bsl;
-
-    bsl::ut_scenario{"verify supports global POD"} = []() {
-        bsl::discard(pod);
-        static_assert(is_pod<decltype(pod)>::value);
-    };
-
-    bsl::ut_scenario{"verify noexcept"} = []() {
-        bsl::ut_given{} = []() {
-            spinlock lck{};
-            bsl::ut_then{} = []() {
-                static_assert(noexcept(spinlock{}));
-                static_assert(noexcept(spinlock{true}));
-                static_assert(noexcept(lck.lock()));
-                static_assert(noexcept(lck.try_lock()));
-                static_assert(noexcept(lck.unlock()));
-            };
-        };
-    };
-
-    return bsl::ut_success();
+        ++args;
+        if (args.front<bsl::string_view>() == "8") {
+            bsl::print() << "success\n";
+        }
+    }
 }

--- a/examples/arguments/example_arguments_size.hpp
+++ b/examples/arguments/example_arguments_size.hpp
@@ -22,45 +22,21 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
-#include <bsl/spinlock.hpp>
-#include <bsl/is_pod.hpp>
-#include <bsl/ut.hpp>
+#include <bsl/arguments.hpp>
+#include <bsl/array.hpp>
+#include <bsl/debug.hpp>
 
-namespace
+namespace bsl
 {
-    bsl::spinlock const pod{};
-}
+    /// <!-- description -->
+    ///   @brief Provides the example's main function
+    ///
+    inline void
+    example_arguments_size() noexcept
+    {
+        constexpr bsl::array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+        bsl::arguments const args{argv.size(), argv.data()};
 
-/// <!-- description -->
-///   @brief Main function for this unit test. If a call to ut_check() fails
-///     the application will fast fail. If all calls to ut_check() pass, this
-///     function will successfully return with bsl::exit_success.
-///
-/// <!-- inputs/outputs -->
-///   @return Always returns bsl::exit_success.
-///
-bsl::exit_code
-main() noexcept
-{
-    using namespace bsl;
-
-    bsl::ut_scenario{"verify supports global POD"} = []() {
-        bsl::discard(pod);
-        static_assert(is_pod<decltype(pod)>::value);
-    };
-
-    bsl::ut_scenario{"verify noexcept"} = []() {
-        bsl::ut_given{} = []() {
-            spinlock lck{};
-            bsl::ut_then{} = []() {
-                static_assert(noexcept(spinlock{}));
-                static_assert(noexcept(spinlock{true}));
-                static_assert(noexcept(lck.lock()));
-                static_assert(noexcept(lck.try_lock()));
-                static_assert(noexcept(lck.unlock()));
-            };
-        };
-    };
-
-    return bsl::ut_success();
+        bsl::print() << "size: " << args.size() << bsl::endl;
+    }
 }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -35,10 +35,16 @@
 #include "example_aligned_storage_overview.hpp"
 // #include "example_aligned_union_overview.hpp"
 #include "example_alignment_of_overview.hpp"
+#include "arguments/example_arguments_at.hpp"
+#include "arguments/example_arguments_back.hpp"
+#include "arguments/example_arguments_empty.hpp"
+#include "arguments/example_arguments_front.hpp"
+#include "arguments/example_arguments_increment.hpp"
 #include "arguments/example_arguments_operator_bool.hpp"
 #include "arguments/example_arguments_opt.hpp"
 #include "arguments/example_arguments_ostream.hpp"
 #include "arguments/example_arguments_pos.hpp"
+#include "arguments/example_arguments_size.hpp"
 #include "example_array_overview.hpp"
 #include "array/example_array_at_if.hpp"
 #include "array/example_array_back_if.hpp"
@@ -486,10 +492,16 @@ main() noexcept
     example(&bsl::example_aligned_storage_overview, "example_aligned_storage_overview");
     // example(&bsl::example_aligned_union_overview, "example_aligned_union_overview");
     example(&bsl::example_alignment_of_overview, "example_alignment_of_overview");
+    example(&bsl::example_arguments_at, "example_arguments_at");
+    example(&bsl::example_arguments_back, "example_arguments_back");
+    example(&bsl::example_arguments_empty, "example_arguments_empty");
+    example(&bsl::example_arguments_front, "example_arguments_front");
+    example(&bsl::example_arguments_increment, "example_arguments_increment");
     example(&bsl::example_arguments_operator_bool, "example_arguments_operator_bool");
     example(&bsl::example_arguments_opt, "example_arguments_opt");
     example(&bsl::example_arguments_ostream, "example_arguments_ostream");
     example(&bsl::example_arguments_pos, "example_arguments_pos");
+    example(&bsl::example_arguments_size, "example_arguments_size");
     example(&bsl::example_array_overview, "example_array_overview");
     example(&bsl::example_array_at_if, "example_array_at_if");
     example(&bsl::example_array_back_if, "example_array_back_if");

--- a/include/bsl/basic_string_view.hpp
+++ b/include/bsl/basic_string_view.hpp
@@ -1298,6 +1298,10 @@ namespace bsl
             return o;
         }
 
+        if (!str) {
+            return o;
+        }
+
         o.write(str.data());
         return o;
     }

--- a/include/bsl/convert.hpp
+++ b/include/bsl/convert.hpp
@@ -38,7 +38,7 @@ namespace bsl
     ///     conversion error occurred that would result in the loss of
     ///     data.
     inline void
-    conversion_failure__narrowing_results_in_loss_of_data() noexcept
+    conversion_failure_narrowing_results_in_loss_of_data() noexcept
     {}
 
     /// <!-- description -->
@@ -78,7 +78,7 @@ namespace bsl
                 }
                 else {
                     if ((f > t_limits::max()) || (f < t_limits::min())) {
-                        conversion_failure__narrowing_results_in_loss_of_data();
+                        conversion_failure_narrowing_results_in_loss_of_data();
                         return safe_integral<T>::zero(true);
                     }
 
@@ -87,7 +87,7 @@ namespace bsl
             }
             else {
                 if (f < static_cast<F>(0)) {
-                    conversion_failure__narrowing_results_in_loss_of_data();
+                    conversion_failure_narrowing_results_in_loss_of_data();
                     return safe_integral<T>::zero(true);
                 }
 
@@ -96,7 +96,7 @@ namespace bsl
                 }
                 else {
                     if (static_cast<bsl::uintmax>(f) > t_limits::max()) {
-                        conversion_failure__narrowing_results_in_loss_of_data();
+                        conversion_failure_narrowing_results_in_loss_of_data();
                         return safe_integral<T>::zero(true);
                     }
 
@@ -111,7 +111,7 @@ namespace bsl
                 }
                 else {
                     if (f > static_cast<bsl::uintmax>(t_limits::max())) {
-                        conversion_failure__narrowing_results_in_loss_of_data();
+                        conversion_failure_narrowing_results_in_loss_of_data();
                         return safe_integral<T>::zero(true);
                     }
 
@@ -124,7 +124,7 @@ namespace bsl
                 }
                 else {
                     if ((f > t_limits::max())) {
-                        conversion_failure__narrowing_results_in_loss_of_data();
+                        conversion_failure_narrowing_results_in_loss_of_data();
                         return safe_integral<T>::zero(true);
                     }
 

--- a/tests/arguments/behavior.cpp
+++ b/tests/arguments/behavior.cpp
@@ -44,7 +44,7 @@ tests() noexcept
     bsl::ut_scenario{"constructors"} = []() {
         bsl::ut_given{} = []() {
             array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
-            arguments args{argv.size(), argv.data()};
+            arguments const args{argv.size(), argv.data()};
             bsl::ut_then{} = [&args]() {
                 bsl::ut_check(args.get<safe_uint64>(to_umax(0)) == to_u64(4));
                 bsl::ut_check(args.get<bool>("-opt1"));
@@ -59,7 +59,7 @@ tests() noexcept
 
         bsl::ut_given{} = []() {
             array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
-            arguments args{argv.size().get(), argv.data()};
+            arguments const args{argv.size().get(), argv.data()};
             bsl::ut_then{} = [&args]() {
                 bsl::ut_check(args.get<safe_uint64>(to_umax(0)) == to_u64(4));
                 bsl::ut_check(args.get<bool>("-opt1"));
@@ -69,6 +69,84 @@ tests() noexcept
                 bsl::ut_check(args.get<bool>("-opt2"));
                 bsl::ut_check(args.get<safe_uint64>(to_umax(4)) == to_u64(23));
                 bsl::ut_check(args.get<safe_uint64>(to_umax(5)) == to_u64(42));
+            };
+        };
+    };
+
+    bsl::ut_scenario{"args"} = []() {
+        bsl::ut_given{} = []() {
+            array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+            arguments const args{argv.size(), argv.data()};
+            bsl::ut_then{} = [&args, &argv]() {
+                bsl::ut_check(args.args().data() == argv.data());
+                bsl::ut_check(args.args().size() == argv.size());
+            };
+        };
+    };
+
+    bsl::ut_scenario{"at"} = []() {
+        bsl::ut_given{} = []() {
+            array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+            arguments const args{argv.size(), argv.data()};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(args.at<bsl::string_view>(to_umax(0)) == "4");
+                bsl::ut_check(args.at<bsl::string_view>(to_umax(1)) == "8");
+                bsl::ut_check(args.at<bsl::string_view>(to_umax(2)) == "15");
+                bsl::ut_check(args.at<bsl::string_view>(to_umax(3)) == "16");
+                bsl::ut_check(args.at<bsl::string_view>(to_umax(4)) == "23");
+                bsl::ut_check(args.at<bsl::string_view>(to_umax(5)) == "42");
+                bsl::ut_check(args.at<bsl::string_view>(to_umax(6)).empty());
+            };
+        };
+    };
+
+    bsl::ut_scenario{"front"} = []() {
+        bsl::ut_given{} = []() {
+            array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+            arguments const args{argv.size(), argv.data()};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(args.front<bsl::string_view>() == "4");
+            };
+        };
+
+        bsl::ut_given{} = []() {
+            arguments const args{0, nullptr};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(args.front<bsl::string_view>().empty());
+            };
+        };
+    };
+
+    bsl::ut_scenario{"back"} = []() {
+        bsl::ut_given{} = []() {
+            array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+            arguments const args{argv.size(), argv.data()};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(args.back<bsl::string_view>() == "42");
+            };
+        };
+
+        bsl::ut_given{} = []() {
+            arguments const args{0, nullptr};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(args.back<bsl::string_view>().empty());
+            };
+        };
+    };
+
+    bsl::ut_scenario{"empty"} = []() {
+        bsl::ut_given{} = []() {
+            array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+            arguments const args{argv.size(), argv.data()};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(!args.empty());
+            };
+        };
+
+        bsl::ut_given{} = []() {
+            arguments const args{0, nullptr};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(args.empty());
             };
         };
     };
@@ -86,6 +164,93 @@ tests() noexcept
             arguments args{argv.size(), argv.data()};
             bsl::ut_then{} = [&args]() {
                 bsl::ut_check(!!args);
+            };
+        };
+    };
+
+    bsl::ut_scenario{"size"} = []() {
+        bsl::ut_given{} = []() {
+            array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+            arguments const args{argv.size(), argv.data()};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(args.size() == to_umax(6));
+            };
+        };
+
+        bsl::ut_given{} = []() {
+            arguments const args{0, nullptr};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(args.size().is_zero());
+            };
+        };
+    };
+
+    bsl::ut_scenario{"increment"} = []() {
+        bsl::ut_given{} = []() {
+            array argv{"4", "-opt1", "8", "15", "16", "-opt2", "23", "42"};
+            arguments args{argv.size(), argv.data()};
+            bsl::ut_when{} = [&args]() {
+                ++args;
+                bsl::ut_then{} = [&args]() {
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(0)) == "8");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(1)) == "15");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(2)) == "16");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(3)) == "23");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(4)) == "42");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(5)).empty());
+                };
+            };
+
+            bsl::ut_when{} = [&args]() {
+                ++args;
+                bsl::ut_then{} = [&args]() {
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(0)) == "15");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(1)) == "16");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(2)) == "23");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(3)) == "42");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(4)).empty());
+                };
+            };
+
+            bsl::ut_when{} = [&args]() {
+                ++args;
+                bsl::ut_then{} = [&args]() {
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(0)) == "16");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(1)) == "23");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(2)) == "42");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(3)).empty());
+                };
+            };
+
+            bsl::ut_when{} = [&args]() {
+                ++args;
+                bsl::ut_then{} = [&args]() {
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(0)) == "23");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(1)) == "42");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(2)).empty());
+                };
+            };
+
+            bsl::ut_when{} = [&args]() {
+                ++args;
+                bsl::ut_then{} = [&args]() {
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(0)) == "42");
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(1)).empty());
+                };
+            };
+
+            bsl::ut_when{} = [&args]() {
+                ++args;
+                bsl::ut_then{} = [&args]() {
+                    bsl::ut_check(args.at<bsl::string_view>(to_umax(0)).empty());
+                };
+            };
+        };
+
+        bsl::ut_given{} = []() {
+            arguments const args{0, nullptr};
+            bsl::ut_then{} = [&args]() {
+                bsl::ut_check(args.size().is_zero());
             };
         };
     };

--- a/tests/array/requirements.cpp
+++ b/tests/array/requirements.cpp
@@ -31,7 +31,7 @@
 
 namespace
 {
-    bsl::array<bsl::safe_uintmax, 6> pod;
+    bsl::array<bsl::safe_uintmax, 6> const pod{};
 
     class fixture_t final
     {

--- a/tests/basic_errc_type/requirements.cpp
+++ b/tests/basic_errc_type/requirements.cpp
@@ -29,7 +29,7 @@
 
 namespace
 {
-    bsl::basic_errc_type<> pod;
+    bsl::basic_errc_type<> const pod{};
 
     class fixture_t final
     {
@@ -81,7 +81,7 @@ main() noexcept
 {
     using namespace bsl;
 
-    bsl::ut_scenario{"verify supports global POD"} = []() {
+    bsl::ut_scenario{"verify supports global const "} = []() {
         bsl::discard(pod);
         static_assert(is_pod<decltype(pod)>::value);
     };

--- a/tests/basic_string_view/behavior_string_view.cpp
+++ b/tests/basic_string_view/behavior_string_view.cpp
@@ -49,7 +49,7 @@ namespace
     };
 
     constexpr bsl::safe_uintmax res_size{bsl::to_umax(10000)};
-    test_string_view<res_size.get()> res{};
+    test_string_view<res_size.get()> res{};    // NOLINT
 
     template<bsl::uintmax N>
     bool
@@ -129,6 +129,16 @@ bsl::exit_code
 main() noexcept
 {
     using namespace bsl;
+
+    bsl::ut_scenario{"empty"} = []() {
+        bsl::ut_when{} = []() {
+            reset();
+            bsl::print() << string_view{};
+            bsl::ut_then{} = []() {
+                bsl::ut_check(res == "");
+            };
+        };
+    };
 
     bsl::ut_scenario{"string_view with no formatting"} = []() {
         bsl::ut_when{} = []() {

--- a/tests/basic_string_view/requirements.cpp
+++ b/tests/basic_string_view/requirements.cpp
@@ -30,7 +30,7 @@
 
 namespace
 {
-    bsl::basic_string_view<bsl::char_type> pod;
+    bsl::basic_string_view<bsl::char_type> const pod{};
 
     class fixture_t final
     {

--- a/tests/byte/requirements.cpp
+++ b/tests/byte/requirements.cpp
@@ -29,7 +29,7 @@
 
 namespace
 {
-    bsl::byte pod;
+    bsl::byte const pod{};
 
     class fixture_t final
     {

--- a/tests/fmt/behavior_bool.cpp
+++ b/tests/fmt/behavior_bool.cpp
@@ -49,7 +49,7 @@ namespace
     };
 
     constexpr bsl::safe_uintmax res_size{bsl::to_umax(256)};
-    test_string_view<res_size.get()> res{};
+    test_string_view<res_size.get()> res{};    // NOLINT
 
     template<bsl::uintmax N>
     bool

--- a/tests/fmt/behavior_char_type.cpp
+++ b/tests/fmt/behavior_char_type.cpp
@@ -49,7 +49,7 @@ namespace
     };
 
     constexpr bsl::safe_uintmax res_size{bsl::to_umax(256)};
-    test_string_view<res_size.get()> res{};
+    test_string_view<res_size.get()> res{};    // NOLINT
 
     template<bsl::uintmax N>
     bool

--- a/tests/fmt/behavior_cstr_type.cpp
+++ b/tests/fmt/behavior_cstr_type.cpp
@@ -49,7 +49,7 @@ namespace
     };
 
     constexpr bsl::safe_uintmax res_size{bsl::to_umax(10000)};
-    test_string_view<res_size.get()> res{};
+    test_string_view<res_size.get()> res{};    // NOLINT
 
     template<bsl::uintmax N>
     bool

--- a/tests/fmt/behavior_integral.cpp
+++ b/tests/fmt/behavior_integral.cpp
@@ -49,7 +49,7 @@ namespace
     };
 
     constexpr bsl::safe_uintmax res_size{bsl::to_umax(256)};
-    test_string_view<res_size.get()> res{};
+    test_string_view<res_size.get()> res{};    // NOLINT
 
     template<bsl::uintmax N>
     bool

--- a/tests/fmt/behavior_null_pointer.cpp
+++ b/tests/fmt/behavior_null_pointer.cpp
@@ -49,7 +49,7 @@ namespace
     };
 
     constexpr bsl::safe_uintmax res_size{bsl::to_umax(256)};
-    test_string_view<res_size.get()> res{};
+    test_string_view<res_size.get()> res{};    // NOLINT
 
     template<bsl::uintmax N>
     bool

--- a/tests/fmt/behavior_void_pointer.cpp
+++ b/tests/fmt/behavior_void_pointer.cpp
@@ -49,7 +49,7 @@ namespace
     };
 
     constexpr bsl::safe_uintmax res_size{bsl::to_umax(256)};
-    test_string_view<res_size.get()> res{};
+    test_string_view<res_size.get()> res{};    // NOLINT
 
     template<bsl::uintmax N>
     bool

--- a/tests/safe_integral/requirements.cpp
+++ b/tests/safe_integral/requirements.cpp
@@ -28,7 +28,7 @@
 
 namespace
 {
-    bsl::safe_int32 pod;
+    bsl::safe_int32 const pod{};
 
     class fixture_t final
     {

--- a/tests/span/requirements.cpp
+++ b/tests/span/requirements.cpp
@@ -30,7 +30,7 @@
 
 namespace
 {
-    bsl::span<bool> pod;
+    bsl::span<bool> const pod{};
 
     class fixture_t final
     {


### PR DESCRIPTION
The bsl::arguments needs some additional APIs for working with
it that make it easy to parse arguments. Specifically, as each
argument is handled, we need the ability to move to the next
argument, while still being able to use something like .front()
which this PR adds.