### PR TITLE
cmake: Add bf_check_dependency

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,9 +2,9 @@ name: CI Tests
 
 on:
   push:
-    branches: [ master ]
+    paths-ignore: ['**.md']
   pull_request:
-    branches: [ master ]
+    paths-ignore: ['**.md']
 
 jobs:
   Doxygen:

--- a/cmake/function/bf_check_dependency.cmake
+++ b/cmake/function/bf_check_dependency.cmake
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2020 Assured Information Security, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+include(${bsl_SOURCE_DIR}/cmake/colors.cmake)
+
+# Check Dependency
+#
+# Check that a dependency overridden with FETCHCONTENT_SOURCE_DIR_<NAME> is
+# pointing to the expected git tag and warn if it isn't.
+#
+# NAME: The name of the dependency to check in FETCHCONTENT_SOURCE_DIR_<NAME>
+# GIT_TAG: The git tag to check against
+#
+macro(bf_check_dependency NAME GIT_TAG)
+    string(TOUPPER ${NAME} NAME_UPPER)
+    if (FETCHCONTENT_SOURCE_DIR_HYPERVISOR)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${FETCHCONTENT_SOURCE_DIR_${NAME_UPPER}} git rev-list -n 1 HEAD
+                        OUTPUT_VARIABLE GIT_HEAD_COMMIT_HASH
+                        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${FETCHCONTENT_SOURCE_DIR_${NAME_UPPER}} git rev-list -n 1 ${GIT_TAG}
+                        OUTPUT_VARIABLE GIT_EXPECTED_COMMIT_HASH
+                        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if (NOT ${GIT_EXPECTED_COMMIT_HASH} STREQUAL ${GIT_HEAD_COMMIT_HASH})
+            message("-- ${BF_COLOR_YLW}Warning: dependency ${FETCHCONTENT_SOURCE_DIR_${NAME_UPPER}} is not pointing to ${GIT_TAG}${BF_COLOR_RST}")
+        endif()
+    endif()
+endmacro(bf_check_dependency)


### PR DESCRIPTION
This patch makes the following changes:
- cmake: Add a `bf_check_dependency(name git_tag)` macro intended to be used by dependees of this project.
- CI: Trigger CI on any branch on push and prevent markdown-only updates to trigger CI.

`bf_check_dependency(name git_tag)` checks that a dependency overridden with FETCHCONTENT_SOURCE_DIR_&lt;NAME> is pointing to the expected git tag and warns if it isn't.

Here is an example of its usage from hypervisor and MicroV:
![dep_warning](https://user-images.githubusercontent.com/2874925/134353095-98a505d3-1ede-4606-881f-5e7e633e55af.png)

